### PR TITLE
Add is unique set operators and add case insensitive operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Note: to compare floating point equality we just check that the difference is le
 
 * `contains`
 * `does_not_contain`
+* `contains_case_insensitive`
+* `does_not_contain_case_insensitive`
 * `equal_to`
 * `not_equal_to`
 * `starts_with`
@@ -296,10 +298,32 @@ Note: to compare floating point equality we just check that the difference is le
 * `non_empty`
 * `empty`
 * `contains_all`
+* `not_contains_all`
 * `exists`
 * `not_exists`
 * `has_equal_length`
 * `has_not_equal_length`
+* `equal_to_case_insensitive`
+* `not_equal_to_case_insensitive`
+* `is_contained_by`
+* `is_not_contained_by`
+* `is_contained_by_case_insensitive`
+* `is_not_contained_by_case_insensitive`
+* `longer_than`
+* `longer_than_or_equal_to`
+* `shorter_than`
+* `shorter_than_or_equal_to`
+* `invalid_date`
+* `date_equal_to`
+* `date_not_equal_to`
+* `date_less_than`
+* `date_less_than_or_equal_to`
+* `date_greater_than`
+* `date_greater_than_or_equal_to`
+* `is_incomplete_date`
+* `is_unique_set`
+* `is_not_unique_set`
+
 ### Returning data to your client
 
 

--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.9'
+__version__ = '1.0.10'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -263,6 +263,13 @@ class DataframeType(BaseType):
                                  format(value))
         return value
 
+    def convert_string_data_to_lower(self, data):
+        if isinstance(data, pd.core.series.Series):
+            data = data.str.lower()
+        else:
+            data = data.lower()
+        return data
+
     @type_operator(FIELD_DATAFRAME)
     def exists(self, other_value):
         target_column = other_value.get("target")
@@ -277,6 +284,26 @@ class DataframeType(BaseType):
         target = other_value.get("target")
         comparator = other_value.get("comparator")
         results = np.where(self.value.get(target) == self.value.get(comparator, comparator), True, False)
+        self.value[f"result_{uuid4()}"] = results
+        return True in results
+
+    @type_operator(FIELD_DATAFRAME)
+    def equal_to_case_insensitive(self, other_value):
+        target = other_value.get("target")
+        comparator = other_value.get("comparator")
+        comparison_data = self.value.get(comparator, comparator)
+        comparison_data = self.convert_string_data_to_lower(comparison_data)
+        results = np.where(self.value.get(target).str.lower() == comparison_data, True, False)
+        self.value[f"result_{uuid4()}"] = results
+        return True in results
+
+    @type_operator(FIELD_DATAFRAME)
+    def not_equal_to_case_insensitive(self, other_value):
+        target = other_value.get("target")
+        comparator = other_value.get("comparator")
+        comparison_data = self.value.get(comparator, comparator)
+        comparison_data = self.convert_string_data_to_lower(comparison_data)
+        results = np.where(self.value.get(target).str.lower() != comparison_data, True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
 
@@ -337,6 +364,26 @@ class DataframeType(BaseType):
         return True in results
 
     @type_operator(FIELD_DATAFRAME)
+    def contains_case_insensitive(self, other_value):
+        target = other_value.get("target")
+        comparator = other_value.get("comparator")
+        comparison_data = self.value.get(comparator, comparator)
+        comparison_data = self.convert_string_data_to_lower(comparison_data)
+        results = np.where(comparison_data in self.value[target].str.lower().values, True, False)
+        self.value[f"result_{uuid4()}"] = results
+        return True in results
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_contain_case_insensitive(self, other_value):
+        target = other_value.get("target")
+        comparator = other_value.get("comparator")
+        comparison_data = self.value.get(comparator, comparator)
+        comparison_data = self.convert_string_data_to_lower(comparison_data)
+        results = np.where(comparison_data not in self.value[target].str.lower().values, True, False)
+        self.value[f"result_{uuid4()}"] = results
+        return True in results
+
+    @type_operator(FIELD_DATAFRAME)
     def is_contained_by(self, other_value):
         target = other_value.get("target")
         comparator = other_value.get("comparator")
@@ -355,16 +402,26 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def is_contained_by_case_insensitive(self, other_value):
         target = other_value.get("target")
-        comparator = [val.lower() for val in other_value.get("comparator", [])]
-        results = self.value[target].str.lower().isin(self.value.get(comparator, comparator))
+        comparator = other_value.get("comparator", [])
+        if isinstance(comparator, list):
+            comparator = [val.lower() for val in comparator]
+        comparison_data = self.value.get(comparator, comparator)
+        if isinstance(comparison_data, pd.core.series.Series):
+            comparison_data = comparison_data.str.lower()
+        results = self.value[target].str.lower().isin(comparison_data)
         self.value[f"result_{uuid4()}"] = results
         return True in results.values
     
     @type_operator(FIELD_DATAFRAME)
     def is_not_contained_by_case_insensitive(self, other_value):
         target = other_value.get("target")
-        comparator = [val.lower() for val in other_value.get("comparator", [])]
-        results = ~self.value[target].str.lower().isin(self.value.get(comparator, comparator))
+        comparator = other_value.get("comparator", [])
+        if isinstance(comparator, list):
+            comparator = [val.lower() for val in comparator]
+        comparison_data = self.value.get(comparator, comparator)
+        if isinstance(comparison_data, pd.core.series.Series):
+            comparison_data = comparison_data.str.lower()
+        results = ~self.value[target].str.lower().isin(comparison_data)
         self.value[f"result_{uuid4()}"] = results
         return True in results.values
     
@@ -507,9 +564,12 @@ class DataframeType(BaseType):
             values = comparator
         else:
             values = self.value[comparator].unique()
-        self.value.get(comparator, comparator)
         return set(values).issubset(set(self.value[target].unique()))
     
+    @type_operator(FIELD_DATAFRAME)
+    def not_contains_all(self, other_value: dict):
+        return not self.contains_all(other_value)
+
     @type_operator(FIELD_DATAFRAME)
     def invalid_date(self, other_value):
         target = other_value.get("target")
@@ -555,7 +615,35 @@ class DataframeType(BaseType):
         results = ~vectorized_is_complete_date(self.value[target])
         self.value[f"result_{uuid4()}"] = results
         return True in results
-       
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_unique_set(self, other_value):
+        target = other_value.get("target")
+        value = other_value.get("comparator")
+        if isinstance(value, list):
+            value.append(target)
+            target_data = value
+        else:
+            target_data = [value, target]
+        counts = self.value[target_data].groupby(target_data)[target].transform('size')
+        results = np.where(counts <= 1, True, False)
+        self.value[f"result_{uuid4()}"] = results
+        return not (False in results)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_unique_set(self, other_value):
+        target = other_value.get("target")
+        value = other_value.get("comparator")
+        if isinstance(value, list):
+            value.append(target)
+            target_data = value
+        else:
+            target_data = [value, target]
+        counts = self.value[target_data].groupby(target_data)[target].transform('size')
+        results = np.where(counts > 1, True, False)
+        self.value[f"result_{uuid4()}"] = results
+        return True in results
+
 
 @export_type
 class GenericType(SelectMultipleType, SelectType, StringType, NumericType, BooleanType, DataframeType):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,3 +1,4 @@
+from pandas.core.frame import DataFrame
 from business_rules.operators import (DataframeType, StringType,
                                       NumericType, BooleanType, SelectType,
                                       SelectMultipleType, GenericType)
@@ -266,6 +267,41 @@ class DataframeOperatorTests(TestCase):
             "comparator": 20
         }))
 
+    def test_equal_to_case_insensitive(self):
+        df = pandas.DataFrame.from_dict({
+            "var1": ["word", "new", "val"],
+            "var2": ["WORD", "test", "VAL"],
+            "var3": ["LET", "GO", "read"]
+        })
+        self.assertTrue(DataframeType(df).equal_to_case_insensitive({
+            "target": "var1",
+            "comparator": "NEW"
+        }))
+        self.assertTrue(DataframeType(df).equal_to_case_insensitive({
+            "target": "var1",
+            "comparator": "var2"
+        }))
+        self.assertFalse(DataframeType(df).equal_to({
+            "target": "var1",
+            "comparator": "var3"
+        }))
+
+    def test_not_equal_to_case_insensitive(self):
+        df = pandas.DataFrame.from_dict({
+            "var1": ["word", "new", "val"],
+            "var2": ["WORD", "test", "VAL"],
+            "var3": ["LET", "GO", "read"],
+            "var4": ["WORD", "NEW", "VAL"]
+        })
+        self.assertFalse(DataframeType(df).not_equal_to_case_insensitive({
+            "target": "var1",
+            "comparator": "var4"
+        }))
+        self.assertTrue(DataframeType(df).not_equal_to_case_insensitive({
+            "target": "var1",
+            "comparator": "var2"
+        }))
+
     def test_less_than(self):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
@@ -398,6 +434,40 @@ class DataframeOperatorTests(TestCase):
             "comparator": "var2"
         }))
 
+    def test_contains_case_insensitive(self):
+        df = pandas.DataFrame.from_dict({
+            "var1": ["pikachu", "charmander", "squirtle"],
+            "var2": ["PIKACHU", "CHARIZARD", "BULBASAUR"],
+            "var3": ["POKEMON", "CHARIZARD", "BULBASAUR"],
+        })
+        self.assertTrue(DataframeType(df).contains_case_insensitive({
+            "target": "var1",
+            "comparator": "PIKACHU"
+        }))
+        self.assertTrue(DataframeType(df).contains_case_insensitive({
+            "target": "var1",
+            "comparator": "var2"
+        }))
+        self.assertFalse(DataframeType(df).contains_case_insensitive({
+            "target": "var1",
+            "comparator": "var3"
+        }))
+
+    def test_does_not_contain_case_insensitive(self):
+        df = pandas.DataFrame.from_dict({
+            "var1": ["pikachu", "charmander", "squirtle"],
+            "var2": ["PIKACHU", "CHARIZARD", "BULBASAUR"],
+            "var3": ["pikachu", "charizard", "bulbasaur"],
+        })
+        self.assertTrue(DataframeType(df).does_not_contain_case_insensitive({
+            "target": "var1",
+            "comparator": "IVYSAUR"
+        }))
+        self.assertFalse(DataframeType(df).does_not_contain_case_insensitive({
+            "target": "var3",
+            "comparator": "var2"
+        }))
+
     def test_is_contained_by(self):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
@@ -451,6 +521,10 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType(df).is_contained_by_case_insensitive({
             "target": "var1",
             "comparator": ["word", "TEST"]
+        }))
+        self.assertTrue(DataframeType(df).is_contained_by_case_insensitive({
+            "target": "var1",
+            "comparator": "var1"
         }))
         self.assertFalse(DataframeType(df).is_contained_by_case_insensitive({
             "target": "var1",
@@ -677,6 +751,26 @@ class DataframeOperatorTests(TestCase):
             "target": "var2",
             "comparator": ["test", "value"],
         }))
+
+    def test_not_contains_all(self):
+        df = pandas.DataFrame.from_dict(
+            {
+                "var1": ['test', 'value', 'word'],
+                "var2": ["test", "value", "test"]
+            }
+        )
+        self.assertTrue(DataframeType(df).contains_all({
+            "target": "var1",
+            "comparator": "var2",
+        }))
+        self.assertFalse(DataframeType(df).contains_all({
+            "target": "var2",
+            "comparator": "var1",
+        }))
+        self.assertTrue(DataframeType(df).contains_all({
+            "target": "var2",
+            "comparator": ["test", "value"],
+        }))
     
     def test_invalid_date(self):
         df = pandas.DataFrame.from_dict(
@@ -821,6 +915,20 @@ class DataframeOperatorTests(TestCase):
         )
         self.assertTrue(DataframeType(df).is_incomplete_date({"target" : "var1"}))
         self.assertFalse(DataframeType(df).is_incomplete_date({"target" : "var2"}))
+
+    def test_is_unique_set(self):
+        df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "OTHER": [1,2,3,4]})
+        self.assertTrue(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": "LAE"}))
+        self.assertTrue(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
+        self.assertFalse(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
+        self.assertFalse(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": "TAE"}))
+
+    def test_is_not_unique_set(self):
+        df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "OTHER": [1,2,3,4]})
+        self.assertFalse(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": "LAE"}))
+        self.assertFalse(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
+        self.assertTrue(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
+        self.assertTrue(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": "TAE"}))
         
 
 class GenericOperatorTests(TestCase):


### PR DESCRIPTION
This PR adds the is_unique_set operators to support determining whether or not a set of values in a dataframe is always unique. This operator provides support for this use case:

Values in ComparisonDataset.Var1 is unique within BaseDataset.Var2, e.g., TA.TAETORD is unique within an TA.ARM

Additionally, this PR adds case_insensitive versions of various operators and the readme is updated to display all operators.