### PR TITLE
Add prefix replacement to support general variable names

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.11'
+__version__ = '1.0.12'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -28,7 +28,6 @@ class BaseType(object):
                  'input_type': m[1].input_type}
                 for m in methods if getattr(m[1], 'is_operator', False)]
 
-
 def export_type(cls):
     """ Decorator to expose the given class to business_rules.export_rule_data. """
     cls.export_in_rule_data = True
@@ -258,6 +257,10 @@ class DataframeType(BaseType):
 
     name = "dataframe"
 
+    def __init__(self, value, column_prefix_map = {}):
+        self.value = self._assert_valid_value_and_cast(value)
+        self.column_prefix_map = column_prefix_map
+
     def _assert_valid_value_and_cast(self, value):
         if not hasattr(value, '__iter__'):
             raise AssertionError("{0} is not a valid select multiple type".
@@ -271,9 +274,21 @@ class DataframeType(BaseType):
             data = data.lower()
         return data
 
+    def replace_prefix(self, value: str) -> str:
+        if isinstance(value, str):
+            for prefix, replacement in self.column_prefix_map.items():
+                if value.startswith(prefix):
+                    return value.replace(prefix, replacement, 1)
+        return value
+
+    def replace_all_prefixes(self, values: [str]) -> [str]:
+        for i in range(len(values)):
+            values[i] = self.replace_prefix(values[i])
+        return values
+
     @type_operator(FIELD_DATAFRAME)
     def exists(self, other_value):
-        target_column = other_value.get("target")
+        target_column = self.replace_prefix(other_value.get("target"))
         return target_column in self.value
 
     @type_operator(FIELD_DATAFRAME)
@@ -282,16 +297,16 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def equal_to(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(target) == self.value.get(comparator, comparator), True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
 
     @type_operator(FIELD_DATAFRAME)
     def equal_to_case_insensitive(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         comparison_data = self.value.get(comparator, comparator)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         results = np.where(self.value.get(target).str.lower() == comparison_data, True, False)
@@ -300,8 +315,8 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def not_equal_to_case_insensitive(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         comparison_data = self.value.get(comparator, comparator)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         results = np.where(self.value.get(target).str.lower() != comparison_data, True, False)
@@ -310,64 +325,64 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def not_equal_to(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(target) != self.value.get(comparator, comparator), True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
     
     @type_operator(FIELD_DATAFRAME)
     def less_than(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(target) < self.value.get(comparator, comparator), True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
     
     @type_operator(FIELD_DATAFRAME)
     def less_than_or_equal_to(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(target) <= self.value.get(comparator, comparator), True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
     
     @type_operator(FIELD_DATAFRAME)
     def greater_than_or_equal_to(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(target) >= self.value.get(comparator, comparator), True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
     
     @type_operator(FIELD_DATAFRAME)
     def greater_than(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(target) > self.value.get(comparator, comparator), True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
     
     @type_operator(FIELD_DATAFRAME)
     def contains(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(comparator, comparator) in self.value[target].values, True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
     
     @type_operator(FIELD_DATAFRAME)
     def does_not_contain(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         results = np.where(self.value.get(comparator, comparator) not in self.value[target].values, True, False)
         self.value[f"result_{uuid4()}"] = results
         return True in results
 
     @type_operator(FIELD_DATAFRAME)
     def contains_case_insensitive(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         comparison_data = self.value.get(comparator, comparator)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         results = np.where(comparison_data in self.value[target].str.lower().values, True, False)
@@ -376,8 +391,8 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def does_not_contain_case_insensitive(self, other_value):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         comparison_data = self.value.get(comparator, comparator)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         results = np.where(comparison_data not in self.value[target].str.lower().values, True, False)
@@ -386,26 +401,35 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def is_contained_by(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
+        if isinstance(comparator, str):
+            # column name provided
+            comparator = self.replace_prefix(comparator)
         results = self.value[target].isin(self.value.get(comparator, comparator))
         self.value[f"result_{uuid4()}"] = results
         return True in results.values
     
     @type_operator(FIELD_DATAFRAME)
     def is_not_contained_by(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
+        if isinstance(comparator, str):
+            # column name provided
+            comparator = self.replace_prefix(comparator)
         results = ~self.value[target].isin(self.value.get(comparator, comparator))
         self.value[f"result_{uuid4()}"] = results
         return True in results.values
     
     @type_operator(FIELD_DATAFRAME)
     def is_contained_by_case_insensitive(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator", [])
         if isinstance(comparator, list):
             comparator = [val.lower() for val in comparator]
+        elif isinstance(comparator, str):
+            # column name provided
+            comparator = self.replace_prefix(comparator)
         comparison_data = self.value.get(comparator, comparator)
         if isinstance(comparison_data, pd.core.series.Series):
             comparison_data = comparison_data.str.lower()
@@ -415,10 +439,13 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def is_not_contained_by_case_insensitive(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator", [])
         if isinstance(comparator, list):
             comparator = [val.lower() for val in comparator]
+        elif isinstance(comparator, str):
+            # column name provided
+            comparator = self.replace_prefix(comparator)
         comparison_data = self.value.get(comparator, comparator)
         if isinstance(comparison_data, pd.core.series.Series):
             comparison_data = comparison_data.str.lower()
@@ -428,7 +455,7 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def prefix_matches_regex(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         prefix = other_value.get("prefix")
         results = self.value[target].map(lambda x: re.search(comparator, x[:prefix]) is not None)
@@ -437,7 +464,7 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def not_prefix_matches_regex(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         prefix = other_value.get("prefix")
         results = self.value[target].map(lambda x: re.search(comparator, x[:prefix]) is None)
@@ -446,7 +473,7 @@ class DataframeType(BaseType):
   
     @type_operator(FIELD_DATAFRAME)
     def suffix_matches_regex(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         suffix = other_value.get("suffix")
         results = self.value[target].apply(lambda x: re.search(comparator, x[-suffix:]) is not None)
@@ -455,7 +482,7 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def not_suffix_matches_regex(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         suffix = other_value.get("suffix")
         results = self.value[target].apply(lambda x: re.search(comparator, x[-suffix:]) is None)
@@ -464,7 +491,7 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def matches_regex(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.match(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -472,7 +499,7 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def not_matches_regex(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = ~self.value[target].str.match(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -480,7 +507,7 @@ class DataframeType(BaseType):
      
     @type_operator(FIELD_DATAFRAME)
     def starts_with(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.startswith(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -488,7 +515,7 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def ends_with(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.endswith(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -496,7 +523,7 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def has_equal_length(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.len().eq(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -504,7 +531,7 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def has_not_equal_length(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.len().ne(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -512,7 +539,7 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def longer_than(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.len().gt(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -520,7 +547,7 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def longer_than_or_equal_to(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.len().ge(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -528,7 +555,7 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def shorter_than(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.len().lt(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -536,7 +563,7 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def shorter_than_or_equal_to(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         results = self.value[target].str.len().le(comparator)
         self.value[f"result_{uuid4()}"] = results
@@ -544,26 +571,27 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def empty(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         results = np.where(pd.isnull(self.value[target]))
         self.value[f"result_{uuid4()}"] = results
         return True in results
 
     @type_operator(FIELD_DATAFRAME)
     def non_empty(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         results = ~np.where(pd.isnull(self.value[target]))
         self.value[f"result_{uuid4()}"] = results
         return True in results
 
     @type_operator(FIELD_DATAFRAME)
     def contains_all(self, other_value: dict):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         if isinstance(comparator, list):
             # get column as array of values
             values = comparator
         else:
+            comparator = self.replace_prefix(comparator)
             values = self.value[comparator].unique()
         return set(values).issubset(set(self.value[target].unique()))
     
@@ -573,14 +601,14 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def invalid_date(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         results = ~vectorized_is_valid(self.value[target])
         self.value[f"result_{uuid4()}"] = results
         return True in results
     
     def date_comparison(self, other_value, operator):
-        target = other_value.get("target")
-        comparator = other_value.get("comparator")
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
         component = other_value.get("date_component")
         results = np.where(operator(vectorized_date_component(component, self.value.get(target)), vectorized_date_component(component, self.value.get(comparator, comparator))), True, False)
         self.value[f"result_{uuid4()}"] = results
@@ -612,20 +640,23 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def is_incomplete_date(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         results = ~vectorized_is_complete_date(self.value[target])
         self.value[f"result_{uuid4()}"] = results
         return True in results
 
     @type_operator(FIELD_DATAFRAME)
     def is_unique_set(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         value = other_value.get("comparator")
+        print(value)
         if isinstance(value, list):
             value.append(target)
             target_data = value
         else:
             target_data = [value, target]
+        target_data = self.replace_all_prefixes(target_data)
+        print(target_data)
         counts = self.value[target_data].groupby(target_data)[target].transform('size')
         results = np.where(counts <= 1, True, False)
         self.value[f"result_{uuid4()}"] = results
@@ -633,8 +664,12 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def is_unique_relationship(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
+        if isinstance(comparator, list):
+            comparator = self.replace_all_prefixes(comparator)
+        else:
+            comparator = self.replace_prefix(comparator)
         grouped_dict = self.value.groupby([comparator])[target].apply(set).to_dict()
         results = np.where(
             vectorized_len(vectorized_get_dict_key(grouped_dict, self.value[comparator])) <= 1, True, False
@@ -644,8 +679,12 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def is_not_unique_relationship(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
+        if isinstance(comparator, list):
+            comparator = self.replace_all_prefixes(comparator)
+        else:
+            comparator = self.replace_prefix(comparator)
         grouped_dict = self.value.groupby([comparator])[target].apply(set).to_dict()
         results = np.where(
             vectorized_len(vectorized_get_dict_key(grouped_dict, self.value[comparator])) > 1, True, False
@@ -655,13 +694,14 @@ class DataframeType(BaseType):
 
     @type_operator(FIELD_DATAFRAME)
     def is_not_unique_set(self, other_value):
-        target = other_value.get("target")
+        target = self.replace_prefix(other_value.get("target"))
         value = other_value.get("comparator")
         if isinstance(value, list):
             value.append(target)
             target_data = value
         else:
             target_data = [value, target]
+        target_data = self.replace_all_prefixes(target_data)
         counts = self.value[target_data].groupby(target_data)[target].transform('size')
         results = np.where(counts > 1, True, False)
         self.value[f"result_{uuid4()}"] = results

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -211,9 +211,10 @@ class DataframeOperatorTests(TestCase):
     def test_exists(self):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
-            "var2": [3,5,6]
+            "var2": [3,5,6],
         })
         self.assertTrue(DataframeType(df).exists({"target": "var1"}))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).exists({"target": "--r1"}))
         self.assertFalse(DataframeType(df).exists({"target": "invalid"}))
 
     def test_not_exists(self):
@@ -223,6 +224,7 @@ class DataframeOperatorTests(TestCase):
         })
         self.assertTrue(DataframeType(df).not_exists({"target": "invalid"}))
         self.assertFalse(DataframeType(df).not_exists({"target": "var1"}))
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).not_exists({"target": "--r1"}))
 
     def test_equal_to(self):
         df = pandas.DataFrame.from_dict({
@@ -237,6 +239,10 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType(df).equal_to({
             "target": "var1",
             "comparator": "var3"
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).equal_to({
+            "target": "--r1",
+            "comparator": "--r3"
         }))
         self.assertFalse(DataframeType(df).equal_to({
             "target": "var1",
@@ -262,8 +268,12 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var2"
         }))
-        self.assertTrue(DataframeType(df).not_equal_to({
-            "target": "var1",
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_equal_to({
+            "target": "--r1",
+            "comparator": "--r2"
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_equal_to({
+            "target": "--r1",
             "comparator": 20
         }))
 
@@ -276,6 +286,10 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType(df).equal_to_case_insensitive({
             "target": "var1",
             "comparator": "NEW"
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).equal_to_case_insensitive({
+            "target": "--r1",
+            "comparator": "--r2"
         }))
         self.assertTrue(DataframeType(df).equal_to_case_insensitive({
             "target": "var1",
@@ -317,6 +331,10 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).less_than({
+            "target": "--r1",
+            "comparator": "var3"
+        }))
         self.assertFalse(DataframeType(df).less_than({
             "target": "var2",
             "comparator": 2
@@ -335,6 +353,10 @@ class DataframeOperatorTests(TestCase):
         })
         self.assertTrue(DataframeType(df).less_than_or_equal_to({
             "target": "var1",
+            "comparator": "var4"
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).less_than_or_equal_to({
+            "target": "--r1",
             "comparator": "var4"
         }))
         self.assertFalse(DataframeType(df).less_than_or_equal_to({
@@ -365,6 +387,10 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }))
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).greater_than({
+            "target": "var1",
+            "comparator": "--r3"
+        }))
         self.assertTrue(DataframeType(df).greater_than({
             "target": "var2",
             "comparator": 2
@@ -384,6 +410,10 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType(df).greater_than_or_equal_to({
             "target": "var1",
             "comparator": "var4"
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).greater_than_or_equal_to({
+            "target": "var1",
+            "comparator": "--r4"
         }))
         self.assertTrue(DataframeType(df).greater_than_or_equal_to({
             "target": "var2",
@@ -409,6 +439,10 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).contains({
+            "target": "var1",
+            "comparator": "--r3"
+        }))
         self.assertFalse(DataframeType(df).contains({
             "target": "var1",
             "comparator": "var2"
@@ -429,6 +463,10 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }))
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).does_not_contain({
+            "target": "var1",
+            "comparator": "--r3"
+        }))
         self.assertTrue(DataframeType(df).does_not_contain({
             "target": "var1",
             "comparator": "var2"
@@ -445,6 +483,10 @@ class DataframeOperatorTests(TestCase):
             "comparator": "PIKACHU"
         }))
         self.assertTrue(DataframeType(df).contains_case_insensitive({
+            "target": "var1",
+            "comparator": "var2"
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).contains_case_insensitive({
             "target": "var1",
             "comparator": "var2"
         }))
@@ -483,6 +525,10 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).is_contained_by({
+            "target": "var1",
+            "comparator": "--r3"
+        }))
         self.assertFalse(DataframeType(df).is_contained_by({
             "target": "var1",
             "comparator": [9, 10, 11]
@@ -502,6 +548,10 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType(df).is_not_contained_by({
             "target": "var1",
             "comparator": "var3"
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).is_not_contained_by({
+            "target": "var1",
+            "comparator": "--r3"
         }))
         self.assertTrue(DataframeType(df).is_not_contained_by({
             "target": "var1",
@@ -530,6 +580,10 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }))
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).is_contained_by_case_insensitive({
+            "target": "var1",
+            "comparator": "--r3"
+        }))
 
     def test_is_not_contained_by_case_insensitive(self):
         df = pandas.DataFrame.from_dict({
@@ -545,6 +599,10 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).is_not_contained_by_case_insensitive({
+            "target": "var1",
+            "comparator": "--r3"
+        }))
 
     def test_prefix_matches_regex(self):
         df = pandas.DataFrame.from_dict({
@@ -552,8 +610,8 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df).prefix_matches_regex({
-            "target": "var2",
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).prefix_matches_regex({
+            "target": "--r2",
             "comparator": "w.*",
             "prefix": 2
         }))
@@ -569,8 +627,8 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df).suffix_matches_regex({
-            "target": "var1",
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).suffix_matches_regex({
+            "target": "--r1",
             "comparator": "es.*",
             "suffix": 3
         }))
@@ -586,8 +644,8 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertFalse(DataframeType(df).not_prefix_matches_regex({
-            "target": "var1",
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).not_prefix_matches_regex({
+            "target": "--r1",
             "comparator": ".*",
             "prefix": 2
         }))
@@ -608,8 +666,8 @@ class DataframeOperatorTests(TestCase):
             "comparator": ".*",
             "suffix": 3
         }))
-        self.assertTrue(DataframeType(df).not_suffix_matches_regex({
-            "target": "var1",
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_suffix_matches_regex({
+            "target": "--r1",
             "comparator": "[0-9].*",
             "suffix": 3
         }))
@@ -620,8 +678,8 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df).matches_regex({
-            "target": "var1",
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).matches_regex({
+            "target": "--r1",
             "comparator": ".*",
         }))
         self.assertFalse(DataframeType(df).matches_regex({
@@ -639,8 +697,8 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": ".*",
         }))
-        self.assertTrue(DataframeType(df).not_matches_regex({
-            "target": "var1",
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_matches_regex({
+            "target": "--r1",
             "comparator": "[0-9].*",
         }))
 
@@ -650,8 +708,8 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df).starts_with({
-            "target": "var1",
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).starts_with({
+            "target": "--r1",
             "comparator": "WO",
         }))
         self.assertFalse(DataframeType(df).starts_with({
@@ -665,8 +723,8 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertFalse(DataframeType(df).ends_with({
-            "target": "var1",
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).ends_with({
+            "target": "--r1",
             "comparator": "abc",
         }))
         self.assertTrue(DataframeType(df).ends_with({
@@ -680,8 +738,8 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'value']
             }
         )
-        df_operator = DataframeType(df)
-        result = df_operator.has_equal_length({"target": "var_1", "comparator": 4})
+        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        result = df_operator.has_equal_length({"target": "--r_1", "comparator": 4})
         self.assertTrue(result)
 
     def test_has_not_equal_length(self):
@@ -690,8 +748,8 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'value']
             }
         )
-        df_operator = DataframeType(df)
-        result = df_operator.has_not_equal_length({"target": "var_1", "comparator": 4})
+        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        result = df_operator.has_not_equal_length({"target": "--r_1", "comparator": 4})
         self.assertTrue(result)
 
     def test_longer_than(self):
@@ -700,8 +758,8 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'value']
             }
         )
-        df_operator = DataframeType(df)
-        self.assertTrue(df_operator.longer_than({"target": "var_1", "comparator": 3}))
+        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        self.assertTrue(df_operator.longer_than({"target": "--r_1", "comparator": 3}))
 
     def test_longer_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -709,8 +767,8 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'alex']
             }
         )
-        df_operator = DataframeType(df)
-        self.assertTrue(df_operator.longer_than_or_equal_to({"target": "var_1", "comparator": 3}))
+        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        self.assertTrue(df_operator.longer_than_or_equal_to({"target": "--r_1", "comparator": 3}))
         self.assertTrue(df_operator.longer_than_or_equal_to({"target": "var_1", "comparator": 4}))
 
     def test_shorter_than(self):
@@ -719,8 +777,8 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'val']
             }
         )
-        df_operator = DataframeType(df)
-        self.assertTrue(df_operator.shorter_than({"target": "var_1", "comparator": 5}))
+        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        self.assertTrue(df_operator.shorter_than({"target": "--r_1", "comparator": 5}))
 
     def test_shorter_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -728,8 +786,8 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'alex']
             }
         )
-        df_operator = DataframeType(df)
-        self.assertTrue(df_operator.shorter_than_or_equal_to({"target": "var_1", "comparator": 5}))
+        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        self.assertTrue(df_operator.shorter_than_or_equal_to({"target": "--r_1", "comparator": 5}))
         self.assertTrue(df_operator.shorter_than_or_equal_to({"target": "var_1", "comparator": 4}))
 
     def test_contains_all(self):
@@ -742,6 +800,10 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType(df).contains_all({
             "target": "var1",
             "comparator": "var2",
+        }))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).contains_all({
+            "target": "--r1",
+            "comparator": "--r2",
         }))
         self.assertFalse(DataframeType(df).contains_all({
             "target": "var2",
@@ -780,7 +842,7 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"], 
             }
         )
-        self.assertFalse(DataframeType(df).invalid_date({"target": "var1"}))
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).invalid_date({"target": "--r1"}))
         self.assertFalse(DataframeType(df).invalid_date({"target": "var3"}))
         self.assertTrue(DataframeType(df).invalid_date({"target": "var2"}))
     
@@ -798,7 +860,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType(df).date_equal_to({"target": "var1", "comparator": '2021'}))
         self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "1997-07-16T19:20:30.45+01:00"}))
         self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var4"}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var4", "date_component": "year"}))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).date_equal_to({"target": "--r3", "comparator": "--r4", "date_component": "year"}))
         self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "hour"}))
         self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "minute"}))
         self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "second"}))
@@ -917,18 +979,22 @@ class DataframeOperatorTests(TestCase):
         self.assertFalse(DataframeType(df).is_incomplete_date({"target" : "var2"}))
 
     def test_is_unique_set(self):
-        df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "OTHER": [1,2,3,4]})
+        df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "ARF": [1,2,3,4]})
         self.assertTrue(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": "LAE"}))
         self.assertTrue(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
         self.assertFalse(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
         self.assertFalse(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": "TAE"}))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "AR"}).is_unique_set({"target" : "--M", "comparator": "--F"}))
+        self.assertTrue(DataframeType(df, column_prefix_map={"--": "AR"}).is_unique_set({"target" : "--M", "comparator": ["--F"]}))
 
     def test_is_not_unique_set(self):
-        df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "OTHER": [1,2,3,4]})
+        df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "ARF": [1,2,3,4]})
         self.assertFalse(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": "LAE"}))
         self.assertFalse(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
         self.assertTrue(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
         self.assertTrue(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": "TAE"}))
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "AR"}).is_not_unique_set({"target" : "--M", "comparator": "--F"}))
+        self.assertFalse(DataframeType(df, column_prefix_map={"--": "AR"}).is_not_unique_set({"target" : "--M", "comparator": ["--F"]}))
 
     def test_is_unique_relationship(self):
         """
@@ -945,6 +1011,11 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(
             DataframeType(one_to_one_related_df).is_unique_relationship(
                 {"target": "STUDYID", "comparator": "STUDYDESC"}
+            )
+        )
+        self.assertTrue(
+            DataframeType(one_to_one_related_df, column_prefix_map={"--": "STUDY"}).is_unique_relationship(
+                {"target": "--ID", "comparator": "--DESC"}
             )
         )
 
@@ -1004,6 +1075,9 @@ class DataframeOperatorTests(TestCase):
         )
         self.assertTrue(DataframeType(df_violates_one_to_one_1).is_not_unique_relationship(
             {"target": "VISIT", "comparator": "VISITDESC"})
+        )
+        self.assertTrue(DataframeType(df_violates_one_to_one_1, column_prefix_map={"--": "VI"}).is_not_unique_relationship(
+            {"target": "--SIT", "comparator": "--SITDESC"})
         )
 
 


### PR DESCRIPTION
This PR adds an optional column name prefix replacement argument to the dataframe type operator. This option allows a user to pass a prefix map to the dataframe type operator that will be replaced anytime an operation is being performed on a column.

This will allow CORE to provide a prefix replacement map {"--": <domain_name>} to support rules on generic columns.