### PR TITLE
Update Dataframe type to take dict as initializing argument

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.12'
+__version__ = '1.0.13'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -257,9 +257,9 @@ class DataframeType(BaseType):
 
     name = "dataframe"
 
-    def __init__(self, value, column_prefix_map = {}):
-        self.value = self._assert_valid_value_and_cast(value)
-        self.column_prefix_map = column_prefix_map
+    def __init__(self, data):
+        self.value = self._assert_valid_value_and_cast(data["value"])
+        self.column_prefix_map = data.get("column_prefix_map", {})
 
     def _assert_valid_value_and_cast(self, value):
         if not hasattr(value, '__iter__'):
@@ -707,7 +707,7 @@ class DataframeType(BaseType):
 
 
 @export_type
-class GenericType(SelectMultipleType, SelectType, StringType, NumericType, BooleanType, DataframeType):
+class GenericType(SelectMultipleType, SelectType, StringType, NumericType, BooleanType):
 
     """
     This is meant to be a generic operator type to support all operations on a given value. Use this when you don't know the type of the value that will be returned.

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -213,18 +213,18 @@ class DataframeOperatorTests(TestCase):
             "var1": [1,2,4],
             "var2": [3,5,6],
         })
-        self.assertTrue(DataframeType(df).exists({"target": "var1"}))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).exists({"target": "--r1"}))
-        self.assertFalse(DataframeType(df).exists({"target": "invalid"}))
+        self.assertTrue(DataframeType({"value": df}).exists({"target": "var1"}))
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).exists({"target": "--r1"}))
+        self.assertFalse(DataframeType({"value": df}).exists({"target": "invalid"}))
 
     def test_not_exists(self):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
             "var2": [3,5,6]
         })
-        self.assertTrue(DataframeType(df).not_exists({"target": "invalid"}))
-        self.assertFalse(DataframeType(df).not_exists({"target": "var1"}))
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).not_exists({"target": "--r1"}))
+        self.assertTrue(DataframeType({"value": df}).not_exists({"target": "invalid"}))
+        self.assertFalse(DataframeType({"value": df}).not_exists({"target": "var1"}))
+        self.assertFalse(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).not_exists({"target": "--r1"}))
 
     def test_equal_to(self):
         df = pandas.DataFrame.from_dict({
@@ -232,23 +232,23 @@ class DataframeOperatorTests(TestCase):
             "var2": [3,5,6],
             "var3": [1,3,8]
         })
-        self.assertTrue(DataframeType(df).equal_to({
+        self.assertTrue(DataframeType({"value": df}).equal_to({
             "target": "var1",
             "comparator": 2
         }))
-        self.assertTrue(DataframeType(df).equal_to({
+        self.assertTrue(DataframeType({"value": df}).equal_to({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).equal_to({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).equal_to({
             "target": "--r1",
             "comparator": "--r3"
         }))
-        self.assertFalse(DataframeType(df).equal_to({
+        self.assertFalse(DataframeType({"value": df}).equal_to({
             "target": "var1",
             "comparator": "var2"
         }))
-        self.assertFalse(DataframeType(df).equal_to({
+        self.assertFalse(DataframeType({"value": df}).equal_to({
             "target": "var1",
             "comparator": 20
         }))
@@ -260,19 +260,19 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertFalse(DataframeType(df).not_equal_to({
+        self.assertFalse(DataframeType({"value": df}).not_equal_to({
             "target": "var1",
             "comparator": "var4"
         }))
-        self.assertTrue(DataframeType(df).not_equal_to({
+        self.assertTrue(DataframeType({"value": df}).not_equal_to({
             "target": "var1",
             "comparator": "var2"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_equal_to({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).not_equal_to({
             "target": "--r1",
             "comparator": "--r2"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_equal_to({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).not_equal_to({
             "target": "--r1",
             "comparator": 20
         }))
@@ -283,19 +283,19 @@ class DataframeOperatorTests(TestCase):
             "var2": ["WORD", "test", "VAL"],
             "var3": ["LET", "GO", "read"]
         })
-        self.assertTrue(DataframeType(df).equal_to_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).equal_to_case_insensitive({
             "target": "var1",
             "comparator": "NEW"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).equal_to_case_insensitive({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).equal_to_case_insensitive({
             "target": "--r1",
             "comparator": "--r2"
         }))
-        self.assertTrue(DataframeType(df).equal_to_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).equal_to_case_insensitive({
             "target": "var1",
             "comparator": "var2"
         }))
-        self.assertFalse(DataframeType(df).equal_to({
+        self.assertFalse(DataframeType({"value": df}).equal_to({
             "target": "var1",
             "comparator": "var3"
         }))
@@ -307,11 +307,11 @@ class DataframeOperatorTests(TestCase):
             "var3": ["LET", "GO", "read"],
             "var4": ["WORD", "NEW", "VAL"]
         })
-        self.assertFalse(DataframeType(df).not_equal_to_case_insensitive({
+        self.assertFalse(DataframeType({"value": df}).not_equal_to_case_insensitive({
             "target": "var1",
             "comparator": "var4"
         }))
-        self.assertTrue(DataframeType(df).not_equal_to_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).not_equal_to_case_insensitive({
             "target": "var1",
             "comparator": "var2"
         }))
@@ -323,23 +323,23 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertFalse(DataframeType(df).less_than({
+        self.assertFalse(DataframeType({"value": df}).less_than({
             "target": "var1",
             "comparator": "var4"
         }))
-        self.assertTrue(DataframeType(df).less_than({
+        self.assertTrue(DataframeType({"value": df}).less_than({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).less_than({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).less_than({
             "target": "--r1",
             "comparator": "var3"
         }))
-        self.assertFalse(DataframeType(df).less_than({
+        self.assertFalse(DataframeType({"value": df}).less_than({
             "target": "var2",
             "comparator": 2
         }))
-        self.assertTrue(DataframeType(df).less_than({
+        self.assertTrue(DataframeType({"value": df}).less_than({
             "target": "var1",
             "comparator": 3
         }))
@@ -351,23 +351,23 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertTrue(DataframeType(df).less_than_or_equal_to({
+        self.assertTrue(DataframeType({"value": df}).less_than_or_equal_to({
             "target": "var1",
             "comparator": "var4"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).less_than_or_equal_to({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).less_than_or_equal_to({
             "target": "--r1",
             "comparator": "var4"
         }))
-        self.assertFalse(DataframeType(df).less_than_or_equal_to({
+        self.assertFalse(DataframeType({"value": df}).less_than_or_equal_to({
             "target": "var2",
             "comparator": "var1"
         }))
-        self.assertFalse(DataframeType(df).less_than_or_equal_to({
+        self.assertFalse(DataframeType({"value": df}).less_than_or_equal_to({
             "target": "var2",
             "comparator": 2
         }))
-        self.assertTrue(DataframeType(df).less_than_or_equal_to({
+        self.assertTrue(DataframeType({"value": df}).less_than_or_equal_to({
             "target": "var2",
             "comparator": "var3"
         }))
@@ -379,23 +379,23 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertFalse(DataframeType(df).greater_than({
+        self.assertFalse(DataframeType({"value": df}).greater_than({
             "target": "var1",
             "comparator": "var4"
         }))
-        self.assertFalse(DataframeType(df).greater_than({
+        self.assertFalse(DataframeType({"value": df}).greater_than({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).greater_than({
+        self.assertFalse(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).greater_than({
             "target": "var1",
             "comparator": "--r3"
         }))
-        self.assertTrue(DataframeType(df).greater_than({
+        self.assertTrue(DataframeType({"value": df}).greater_than({
             "target": "var2",
             "comparator": 2
         }))
-        self.assertFalse(DataframeType(df).greater_than({
+        self.assertFalse(DataframeType({"value": df}).greater_than({
             "target": "var1",
             "comparator": 5000
         }))
@@ -407,19 +407,19 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertTrue(DataframeType(df).greater_than_or_equal_to({
+        self.assertTrue(DataframeType({"value": df}).greater_than_or_equal_to({
             "target": "var1",
             "comparator": "var4"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).greater_than_or_equal_to({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).greater_than_or_equal_to({
             "target": "var1",
             "comparator": "--r4"
         }))
-        self.assertTrue(DataframeType(df).greater_than_or_equal_to({
+        self.assertTrue(DataframeType({"value": df}).greater_than_or_equal_to({
             "target": "var2",
             "comparator": "var3"
         }))
-        self.assertTrue(DataframeType(df).greater_than_or_equal_to({
+        self.assertTrue(DataframeType({"value": df}).greater_than_or_equal_to({
             "target": "var2",
             "comparator": 2
         }))
@@ -431,19 +431,19 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertTrue(DataframeType(df).contains({
+        self.assertTrue(DataframeType({"value": df}).contains({
             "target": "var1",
             "comparator": 2
         }))
-        self.assertTrue(DataframeType(df).contains({
+        self.assertTrue(DataframeType({"value": df}).contains({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).contains({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).contains({
             "target": "var1",
             "comparator": "--r3"
         }))
-        self.assertFalse(DataframeType(df).contains({
+        self.assertFalse(DataframeType({"value": df}).contains({
             "target": "var1",
             "comparator": "var2"
         }))
@@ -455,19 +455,19 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertTrue(DataframeType(df).does_not_contain({
+        self.assertTrue(DataframeType({"value": df}).does_not_contain({
             "target": "var1",
             "comparator": 5
         }))
-        self.assertFalse(DataframeType(df).does_not_contain({
+        self.assertFalse(DataframeType({"value": df}).does_not_contain({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).does_not_contain({
+        self.assertFalse(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).does_not_contain({
             "target": "var1",
             "comparator": "--r3"
         }))
-        self.assertTrue(DataframeType(df).does_not_contain({
+        self.assertTrue(DataframeType({"value": df}).does_not_contain({
             "target": "var1",
             "comparator": "var2"
         }))
@@ -478,19 +478,19 @@ class DataframeOperatorTests(TestCase):
             "var2": ["PIKACHU", "CHARIZARD", "BULBASAUR"],
             "var3": ["POKEMON", "CHARIZARD", "BULBASAUR"],
         })
-        self.assertTrue(DataframeType(df).contains_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).contains_case_insensitive({
             "target": "var1",
             "comparator": "PIKACHU"
         }))
-        self.assertTrue(DataframeType(df).contains_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).contains_case_insensitive({
             "target": "var1",
             "comparator": "var2"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).contains_case_insensitive({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).contains_case_insensitive({
             "target": "var1",
             "comparator": "var2"
         }))
-        self.assertFalse(DataframeType(df).contains_case_insensitive({
+        self.assertFalse(DataframeType({"value": df}).contains_case_insensitive({
             "target": "var1",
             "comparator": "var3"
         }))
@@ -501,11 +501,11 @@ class DataframeOperatorTests(TestCase):
             "var2": ["PIKACHU", "CHARIZARD", "BULBASAUR"],
             "var3": ["pikachu", "charizard", "bulbasaur"],
         })
-        self.assertTrue(DataframeType(df).does_not_contain_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).does_not_contain_case_insensitive({
             "target": "var1",
             "comparator": "IVYSAUR"
         }))
-        self.assertFalse(DataframeType(df).does_not_contain_case_insensitive({
+        self.assertFalse(DataframeType({"value": df}).does_not_contain_case_insensitive({
             "target": "var3",
             "comparator": "var2"
         }))
@@ -517,23 +517,23 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertTrue(DataframeType(df).is_contained_by({
+        self.assertTrue(DataframeType({"value": df}).is_contained_by({
             "target": "var1",
             "comparator": [4,5,6]
         }))
-        self.assertTrue(DataframeType(df).is_contained_by({
+        self.assertTrue(DataframeType({"value": df}).is_contained_by({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).is_contained_by({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).is_contained_by({
             "target": "var1",
             "comparator": "--r3"
         }))
-        self.assertFalse(DataframeType(df).is_contained_by({
+        self.assertFalse(DataframeType({"value": df}).is_contained_by({
             "target": "var1",
             "comparator": [9, 10, 11]
         }))
-        self.assertFalse(DataframeType(df).is_contained_by({
+        self.assertFalse(DataframeType({"value": df}).is_contained_by({
             "target": "var1",
             "comparator": "var2"
         }))
@@ -545,19 +545,19 @@ class DataframeOperatorTests(TestCase):
             "var3": [1,3,8],
             "var4": [1,2,4]
         })
-        self.assertTrue(DataframeType(df).is_not_contained_by({
+        self.assertTrue(DataframeType({"value": df}).is_not_contained_by({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).is_not_contained_by({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).is_not_contained_by({
             "target": "var1",
             "comparator": "--r3"
         }))
-        self.assertTrue(DataframeType(df).is_not_contained_by({
+        self.assertTrue(DataframeType({"value": df}).is_not_contained_by({
             "target": "var1",
             "comparator": [9, 10, 11]
         }))
-        self.assertFalse(DataframeType(df).is_not_contained_by({
+        self.assertFalse(DataframeType({"value": df}).is_not_contained_by({
             "target": "var1",
             "comparator": "var1"
         }))
@@ -568,19 +568,19 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df).is_contained_by_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).is_contained_by_case_insensitive({
             "target": "var1",
             "comparator": ["word", "TEST"]
         }))
-        self.assertTrue(DataframeType(df).is_contained_by_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).is_contained_by_case_insensitive({
             "target": "var1",
             "comparator": "var1"
         }))
-        self.assertFalse(DataframeType(df).is_contained_by_case_insensitive({
+        self.assertFalse(DataframeType({"value": df}).is_contained_by_case_insensitive({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).is_contained_by_case_insensitive({
+        self.assertFalse(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).is_contained_by_case_insensitive({
             "target": "var1",
             "comparator": "--r3"
         }))
@@ -591,15 +591,15 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertFalse(DataframeType(df).is_not_contained_by_case_insensitive({
+        self.assertFalse(DataframeType({"value": df}).is_not_contained_by_case_insensitive({
             "target": "var1",
             "comparator": ["word", "TEST"]
         }))
-        self.assertTrue(DataframeType(df).is_not_contained_by_case_insensitive({
+        self.assertTrue(DataframeType({"value": df}).is_not_contained_by_case_insensitive({
             "target": "var1",
             "comparator": "var3"
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).is_not_contained_by_case_insensitive({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).is_not_contained_by_case_insensitive({
             "target": "var1",
             "comparator": "--r3"
         }))
@@ -610,12 +610,12 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).prefix_matches_regex({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).prefix_matches_regex({
             "target": "--r2",
             "comparator": "w.*",
             "prefix": 2
         }))
-        self.assertFalse(DataframeType(df).prefix_matches_regex({
+        self.assertFalse(DataframeType({"value": df}).prefix_matches_regex({
             "target": "var2",
             "comparator": "[0-9].*",
             "prefix": 2
@@ -627,12 +627,12 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).suffix_matches_regex({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).suffix_matches_regex({
             "target": "--r1",
             "comparator": "es.*",
             "suffix": 3
         }))
-        self.assertFalse(DataframeType(df).suffix_matches_regex({
+        self.assertFalse(DataframeType({"value": df}).suffix_matches_regex({
             "target": "var1",
             "comparator": "[0-9].*",
             "suffix": 3
@@ -644,12 +644,12 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).not_prefix_matches_regex({
+        self.assertFalse(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).not_prefix_matches_regex({
             "target": "--r1",
             "comparator": ".*",
             "prefix": 2
         }))
-        self.assertTrue(DataframeType(df).not_prefix_matches_regex({
+        self.assertTrue(DataframeType({"value": df}).not_prefix_matches_regex({
             "target": "var2",
             "comparator": "[0-9].*",
             "prefix": 2
@@ -661,12 +661,12 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertFalse(DataframeType(df).not_suffix_matches_regex({
+        self.assertFalse(DataframeType({"value": df}).not_suffix_matches_regex({
             "target": "var1",
             "comparator": ".*",
             "suffix": 3
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_suffix_matches_regex({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).not_suffix_matches_regex({
             "target": "--r1",
             "comparator": "[0-9].*",
             "suffix": 3
@@ -678,11 +678,11 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).matches_regex({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).matches_regex({
             "target": "--r1",
             "comparator": ".*",
         }))
-        self.assertFalse(DataframeType(df).matches_regex({
+        self.assertFalse(DataframeType({"value": df}).matches_regex({
             "target": "var2",
             "comparator": "[0-9].*",
         }))
@@ -693,11 +693,11 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertFalse(DataframeType(df).not_matches_regex({
+        self.assertFalse(DataframeType({"value": df}).not_matches_regex({
             "target": "var1",
             "comparator": ".*",
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).not_matches_regex({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).not_matches_regex({
             "target": "--r1",
             "comparator": "[0-9].*",
         }))
@@ -708,11 +708,11 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).starts_with({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).starts_with({
             "target": "--r1",
             "comparator": "WO",
         }))
-        self.assertFalse(DataframeType(df).starts_with({
+        self.assertFalse(DataframeType({"value": df}).starts_with({
             "target": "var2",
             "comparator": "ABC",
         }))
@@ -723,11 +723,11 @@ class DataframeOperatorTests(TestCase):
             "var2": ["word", "TEST"],
             "var3": ["another", "item"]
         })
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).ends_with({
+        self.assertFalse(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).ends_with({
             "target": "--r1",
             "comparator": "abc",
         }))
-        self.assertTrue(DataframeType(df).ends_with({
+        self.assertTrue(DataframeType({"value": df}).ends_with({
             "target": "var1",
             "comparator": "est",
         }))
@@ -738,7 +738,7 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'value']
             }
         )
-        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        df_operator = DataframeType({"value": df, "column_prefix_map": {"--": "va"}})
         result = df_operator.has_equal_length({"target": "--r_1", "comparator": 4})
         self.assertTrue(result)
 
@@ -748,7 +748,7 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'value']
             }
         )
-        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        df_operator = DataframeType({"value": df, "column_prefix_map": {"--": "va"}})
         result = df_operator.has_not_equal_length({"target": "--r_1", "comparator": 4})
         self.assertTrue(result)
 
@@ -758,7 +758,7 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'value']
             }
         )
-        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        df_operator = DataframeType({"value": df, "column_prefix_map": {"--": "va"}})
         self.assertTrue(df_operator.longer_than({"target": "--r_1", "comparator": 3}))
 
     def test_longer_than_or_equal_to(self):
@@ -767,7 +767,7 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'alex']
             }
         )
-        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        df_operator = DataframeType({"value": df, "column_prefix_map": {"--": "va"}})
         self.assertTrue(df_operator.longer_than_or_equal_to({"target": "--r_1", "comparator": 3}))
         self.assertTrue(df_operator.longer_than_or_equal_to({"target": "var_1", "comparator": 4}))
 
@@ -777,7 +777,7 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'val']
             }
         )
-        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        df_operator = DataframeType({"value": df, "column_prefix_map": {"--": "va"}})
         self.assertTrue(df_operator.shorter_than({"target": "--r_1", "comparator": 5}))
 
     def test_shorter_than_or_equal_to(self):
@@ -786,7 +786,7 @@ class DataframeOperatorTests(TestCase):
                 "var_1": ['test', 'alex']
             }
         )
-        df_operator = DataframeType(df, column_prefix_map={"--": "va"})
+        df_operator = DataframeType({"value": df, "column_prefix_map": {"--": "va"}})
         self.assertTrue(df_operator.shorter_than_or_equal_to({"target": "--r_1", "comparator": 5}))
         self.assertTrue(df_operator.shorter_than_or_equal_to({"target": "var_1", "comparator": 4}))
 
@@ -797,19 +797,19 @@ class DataframeOperatorTests(TestCase):
                 "var2": ["test", "value", "test"]
             }
         )
-        self.assertTrue(DataframeType(df).contains_all({
+        self.assertTrue(DataframeType({"value": df}).contains_all({
             "target": "var1",
             "comparator": "var2",
         }))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).contains_all({
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).contains_all({
             "target": "--r1",
             "comparator": "--r2",
         }))
-        self.assertFalse(DataframeType(df).contains_all({
+        self.assertFalse(DataframeType({"value": df}).contains_all({
             "target": "var2",
             "comparator": "var1",
         }))
-        self.assertTrue(DataframeType(df).contains_all({
+        self.assertTrue(DataframeType({"value": df}).contains_all({
             "target": "var2",
             "comparator": ["test", "value"],
         }))
@@ -821,15 +821,15 @@ class DataframeOperatorTests(TestCase):
                 "var2": ["test", "value", "test"]
             }
         )
-        self.assertTrue(DataframeType(df).contains_all({
+        self.assertTrue(DataframeType({"value": df}).contains_all({
             "target": "var1",
             "comparator": "var2",
         }))
-        self.assertFalse(DataframeType(df).contains_all({
+        self.assertFalse(DataframeType({"value": df}).contains_all({
             "target": "var2",
             "comparator": "var1",
         }))
-        self.assertTrue(DataframeType(df).contains_all({
+        self.assertTrue(DataframeType({"value": df}).contains_all({
             "target": "var2",
             "comparator": ["test", "value"],
         }))
@@ -842,9 +842,9 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"], 
             }
         )
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "va"}).invalid_date({"target": "--r1"}))
-        self.assertFalse(DataframeType(df).invalid_date({"target": "var3"}))
-        self.assertTrue(DataframeType(df).invalid_date({"target": "var2"}))
+        self.assertFalse(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).invalid_date({"target": "--r1"}))
+        self.assertFalse(DataframeType({"value": df}).invalid_date({"target": "var3"}))
+        self.assertTrue(DataframeType({"value": df}).invalid_date({"target": "var2"}))
     
     def test_date_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -857,18 +857,18 @@ class DataframeOperatorTests(TestCase):
                 "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
             }
         )
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var1", "comparator": '2021'}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "1997-07-16T19:20:30.45+01:00"}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var4"}))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "va"}).date_equal_to({"target": "--r3", "comparator": "--r4", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "hour"}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "minute"}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "second"}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "microsecond"}))
-        self.assertTrue(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "year"}))
-        self.assertFalse(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "month"}))
-        self.assertFalse(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var6", "date_component": "year"}))
-        self.assertFalse(DataframeType(df).date_equal_to({"target": "var3", "comparator": "var6", "date_component": "month"}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var1", "comparator": '2021'}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "1997-07-16T19:20:30.45+01:00"}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var4"}))
+        self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).date_equal_to({"target": "--r3", "comparator": "--r4", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "hour"}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "minute"}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "second"}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "microsecond"}))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "year"}))
+        self.assertFalse(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var5", "date_component": "month"}))
+        self.assertFalse(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var6", "date_component": "year"}))
+        self.assertFalse(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var6", "date_component": "month"}))
     
     def test_date_not_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -881,22 +881,22 @@ class DataframeOperatorTests(TestCase):
                 "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
             }
         )
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var1", "comparator": '2022'}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "1998-07-16T19:20:30.45+01:00"}))
-        self.assertFalse(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var4"}))
-        self.assertFalse(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var4", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "hour"}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "minute"}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "second"}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "microsecond"}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "month"}))
-        self.assertFalse(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "month"}))
-        self.assertFalse(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "day"}))
-        self.assertFalse(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "hour"}))
-        self.assertFalse(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "second"}))
-        self.assertFalse(DataframeType(df).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "microsecond"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var1", "comparator": '2022'}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "1998-07-16T19:20:30.45+01:00"}))
+        self.assertFalse(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var4"}))
+        self.assertFalse(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var4", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "hour"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "minute"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "second"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "microsecond"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "month"}))
+        self.assertFalse(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "month"}))
+        self.assertFalse(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "day"}))
+        self.assertFalse(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "hour"}))
+        self.assertFalse(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "second"}))
+        self.assertFalse(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var5", "date_component": "microsecond"}))
     
     def test_date_less_than(self):
         df = pandas.DataFrame.from_dict(
@@ -909,11 +909,11 @@ class DataframeOperatorTests(TestCase):
                 "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
             }
         )
-        self.assertTrue(DataframeType(df).date_less_than({"target": "var1", "comparator": '2022'}))
-        self.assertTrue(DataframeType(df).date_less_than({"target": "var3", "comparator": "1998-07-16T19:20:30.45+01:00"}))
-        self.assertFalse(DataframeType(df).date_less_than({"target": "var3", "comparator": "var4"}))
-        self.assertFalse(DataframeType(df).date_less_than({"target": "var3", "comparator": "var4", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_less_than({"target": "var3", "comparator": "var6", "date_component": "hour"}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than({"target": "var1", "comparator": '2022'}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than({"target": "var3", "comparator": "1998-07-16T19:20:30.45+01:00"}))
+        self.assertFalse(DataframeType({"value": df}).date_less_than({"target": "var3", "comparator": "var4"}))
+        self.assertFalse(DataframeType({"value": df}).date_less_than({"target": "var3", "comparator": "var4", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than({"target": "var3", "comparator": "var6", "date_component": "hour"}))
 
     def test_date_greater_than(self):
         df = pandas.DataFrame.from_dict(
@@ -926,11 +926,11 @@ class DataframeOperatorTests(TestCase):
                 "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
             }
         )
-        self.assertTrue(DataframeType(df).date_greater_than({"target": "var1", "comparator": '2020'}))
-        self.assertTrue(DataframeType(df).date_greater_than({"target": "var3", "comparator": "1996-07-16T19:20:30.45+01:00"}))
-        self.assertFalse(DataframeType(df).date_greater_than({"target": "var3", "comparator": "var4"}))
-        self.assertFalse(DataframeType(df).date_greater_than({"target": "var3", "comparator": "var4", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_greater_than({"target": "var6", "comparator": "var3", "date_component": "hour"}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than({"target": "var1", "comparator": '2020'}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than({"target": "var3", "comparator": "1996-07-16T19:20:30.45+01:00"}))
+        self.assertFalse(DataframeType({"value": df}).date_greater_than({"target": "var3", "comparator": "var4"}))
+        self.assertFalse(DataframeType({"value": df}).date_greater_than({"target": "var3", "comparator": "var4", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than({"target": "var6", "comparator": "var3", "date_component": "hour"}))
     
     def test_date_greater_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -943,12 +943,12 @@ class DataframeOperatorTests(TestCase):
                 "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
             }
         )
-        self.assertTrue(DataframeType(df).date_greater_than_or_equal_to({"target": "var1", "comparator": '2020'}))
-        self.assertFalse(DataframeType(df).date_greater_than_or_equal_to({"target": "var1", "comparator": '2023'}))
-        self.assertTrue(DataframeType(df).date_greater_than_or_equal_to({"target": "var3", "comparator": "1996-07-16T19:20:30.45+01:00"}))
-        self.assertTrue(DataframeType(df).date_greater_than_or_equal_to({"target": "var3", "comparator": "var4"}))
-        self.assertTrue(DataframeType(df).date_greater_than_or_equal_to({"target": "var3", "comparator": "var4", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_greater_than_or_equal_to({"target": "var6", "comparator": "var3", "date_component": "hour"}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var1", "comparator": '2020'}))
+        self.assertFalse(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var1", "comparator": '2023'}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var3", "comparator": "1996-07-16T19:20:30.45+01:00"}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var3", "comparator": "var4"}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var3", "comparator": "var4", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var6", "comparator": "var3", "date_component": "hour"}))
     
     def test_date_less_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -961,12 +961,12 @@ class DataframeOperatorTests(TestCase):
                 "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
             }
         )
-        self.assertTrue(DataframeType(df).date_less_than_or_equal_to({"target": "var1", "comparator": '2022'}))
-        self.assertFalse(DataframeType(df).date_less_than_or_equal_to({"target": "var1", "comparator": '2020'}))
-        self.assertTrue(DataframeType(df).date_less_than_or_equal_to({"target": "var3", "comparator": "1998-07-16T19:20:30.45+01:00"}))
-        self.assertTrue(DataframeType(df).date_less_than_or_equal_to({"target": "var3", "comparator": "var4"}))
-        self.assertTrue(DataframeType(df).date_less_than_or_equal_to({"target": "var3", "comparator": "var4", "date_component": "year"}))
-        self.assertTrue(DataframeType(df).date_less_than_or_equal_to({"target": "var6", "comparator": "var3", "date_component": "hour"}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var1", "comparator": '2022'}))
+        self.assertFalse(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var1", "comparator": '2020'}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var3", "comparator": "1998-07-16T19:20:30.45+01:00"}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var3", "comparator": "var4"}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var3", "comparator": "var4", "date_component": "year"}))
+        self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var6", "comparator": "var3", "date_component": "hour"}))
         
     def test_is_complete_date(self):
         df = pandas.DataFrame.from_dict(
@@ -975,26 +975,26 @@ class DataframeOperatorTests(TestCase):
                 "var2": [ "1997-07-16", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"], 
             }
         )
-        self.assertTrue(DataframeType(df).is_incomplete_date({"target" : "var1"}))
-        self.assertFalse(DataframeType(df).is_incomplete_date({"target" : "var2"}))
+        self.assertTrue(DataframeType({"value": df}).is_incomplete_date({"target" : "var1"}))
+        self.assertFalse(DataframeType({"value": df}).is_incomplete_date({"target" : "var2"}))
 
     def test_is_unique_set(self):
         df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "ARF": [1,2,3,4]})
-        self.assertTrue(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": "LAE"}))
-        self.assertTrue(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
-        self.assertFalse(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
-        self.assertFalse(DataframeType(df).is_unique_set({"target" : "ARM", "comparator": "TAE"}))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "AR"}).is_unique_set({"target" : "--M", "comparator": "--F"}))
-        self.assertTrue(DataframeType(df, column_prefix_map={"--": "AR"}).is_unique_set({"target" : "--M", "comparator": ["--F"]}))
+        self.assertTrue(DataframeType({"value": df}).is_unique_set({"target" : "ARM", "comparator": "LAE"}))
+        self.assertTrue(DataframeType({"value": df}).is_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
+        self.assertFalse(DataframeType({"value": df}).is_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
+        self.assertFalse(DataframeType({"value": df}).is_unique_set({"target" : "ARM", "comparator": "TAE"}))
+        self.assertTrue(DataframeType({"value":df, "column_prefix_map": {"--": "AR"}}).is_unique_set({"target" : "--M", "comparator": "--F"}))
+        self.assertTrue(DataframeType({"value":df, "column_prefix_map": {"--": "AR"}}).is_unique_set({"target" : "--M", "comparator": ["--F"]}))
 
     def test_is_not_unique_set(self):
         df = pandas.DataFrame.from_dict( {"ARM": ["PLACEBO", "PLACEBO", "A", "A"], "TAE": [1,1,1,2], "LAE": [1,2,1,2], "ARF": [1,2,3,4]})
-        self.assertFalse(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": "LAE"}))
-        self.assertFalse(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
-        self.assertTrue(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
-        self.assertTrue(DataframeType(df).is_not_unique_set({"target" : "ARM", "comparator": "TAE"}))
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "AR"}).is_not_unique_set({"target" : "--M", "comparator": "--F"}))
-        self.assertFalse(DataframeType(df, column_prefix_map={"--": "AR"}).is_not_unique_set({"target" : "--M", "comparator": ["--F"]}))
+        self.assertFalse(DataframeType({"value": df}).is_not_unique_set({"target" : "ARM", "comparator": "LAE"}))
+        self.assertFalse(DataframeType({"value": df}).is_not_unique_set({"target" : "ARM", "comparator": ["LAE"]}))
+        self.assertTrue(DataframeType({"value": df}).is_not_unique_set({"target" : "ARM", "comparator": ["TAE"]}))
+        self.assertTrue(DataframeType({"value": df}).is_not_unique_set({"target" : "ARM", "comparator": "TAE"}))
+        self.assertFalse(DataframeType({"value":df, "column_prefix_map": {"--": "AR"}}).is_not_unique_set({"target" : "--M", "comparator": "--F"}))
+        self.assertFalse(DataframeType({"value":df, "column_prefix_map": {"--": "AR"}}).is_not_unique_set({"target" : "--M", "comparator": ["--F"]}))
 
     def test_is_unique_relationship(self):
         """
@@ -1009,12 +1009,12 @@ class DataframeOperatorTests(TestCase):
             }
         )
         self.assertTrue(
-            DataframeType(one_to_one_related_df).is_unique_relationship(
+            DataframeType({"value": one_to_one_related_df}).is_unique_relationship(
                 {"target": "STUDYID", "comparator": "STUDYDESC"}
             )
         )
         self.assertTrue(
-            DataframeType(one_to_one_related_df, column_prefix_map={"--": "STUDY"}).is_unique_relationship(
+            DataframeType({"value": one_to_one_related_df, "column_prefix_map":{"--": "STUDY"}}).is_unique_relationship(
                 {"target": "--ID", "comparator": "--DESC"}
             )
         )
@@ -1025,7 +1025,7 @@ class DataframeOperatorTests(TestCase):
                 "TESTNAME": ["Functional", "Stress", "Functional", "Stress", ],
             }
         )
-        self.assertFalse(DataframeType(df_violates_one_to_one).is_unique_relationship(
+        self.assertFalse(DataframeType({"value": df_violates_one_to_one}).is_unique_relationship(
             {"target": "TESTID", "comparator": "TESTNAME"})
         )
 
@@ -1041,7 +1041,7 @@ class DataframeOperatorTests(TestCase):
                 "VISIT": ["Consulting", "Surgery", "Consulting", "Treatment", ],
             }
         )
-        self.assertFalse(DataframeType(valid_df).is_not_unique_relationship(
+        self.assertFalse(DataframeType({"value": valid_df}).is_not_unique_relationship(
             {"target": "VISITNUM", "comparator": "VISIT"})
         )
 
@@ -1053,7 +1053,7 @@ class DataframeOperatorTests(TestCase):
                 ],
             }
         )
-        self.assertFalse(DataframeType(valid_df_1).is_not_unique_relationship(
+        self.assertFalse(DataframeType({"value": valid_df_1}).is_not_unique_relationship(
             {"target": "VISIT", "comparator": "VISITDESC"})
         )
 
@@ -1063,7 +1063,7 @@ class DataframeOperatorTests(TestCase):
                 "VISIT": ["Consulting", "Surgery", "Consulting", "Consulting", ],
             }
         )
-        self.assertTrue(DataframeType(df_violates_one_to_one).is_not_unique_relationship(
+        self.assertTrue(DataframeType({"value": df_violates_one_to_one}).is_not_unique_relationship(
             {"target": "VISITNUM", "comparator": "VISIT"})
         )
 
@@ -1073,10 +1073,10 @@ class DataframeOperatorTests(TestCase):
                 "VISITDESC": ["Doctor Consultation", "Heart Surgery", "Heart Surgery", "Long Lasting Treatment", ],
             }
         )
-        self.assertTrue(DataframeType(df_violates_one_to_one_1).is_not_unique_relationship(
+        self.assertTrue(DataframeType({"value": df_violates_one_to_one_1}).is_not_unique_relationship(
             {"target": "VISIT", "comparator": "VISITDESC"})
         )
-        self.assertTrue(DataframeType(df_violates_one_to_one_1, column_prefix_map={"--": "VI"}).is_not_unique_relationship(
+        self.assertTrue(DataframeType({"value": df_violates_one_to_one_1, "column_prefix_map": {"--": "VI"}}).is_not_unique_relationship(
             {"target": "--SIT", "comparator": "--SITDESC"})
         )
 
@@ -1203,19 +1203,3 @@ class GenericOperatorTests(TestCase):
     def test_is_not_contained_by(self):
         self.assertTrue(GenericType("rat").is_not_contained_by(["moose", "chicken"]))
         self.assertFalse(GenericType("chicken").is_not_contained_by(["moose", "chicken"]))
-
-    def test_exists(self):
-        df = pandas.DataFrame.from_dict({
-            "var1": [1,2,4],
-            "var2": [3,5,6]
-        })
-        self.assertTrue(GenericType(df).exists({"target": "var1"}))
-        self.assertFalse(GenericType(df).exists({"target": "invalid"}))
-
-    def test_not_exists(self):
-        df = pandas.DataFrame.from_dict({
-            "var1": [1,2,4],
-            "var2": [3,5,6]
-        })
-        self.assertTrue(GenericType(df).not_exists({"target": "invalid"}))
-        self.assertFalse(GenericType(df).not_exists({"target": "var1"}))


### PR DESCRIPTION
The last PR introduced an additional argument to the Dataframe type operator. Unfortunately, in order to use additional arguments to the init method, the arguments must be wrapped in a dictionary of parameters. This PR updates the dataframe type to accept a dictionary of parameters with a mandatory "value" key. 

This will allow us to pass options to the DataframeType when evaluating rules