### PR TITLE
Add relationship and reference checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ Note: to compare floating point equality we just check that the difference is le
 * `is_not_unique_set`
 * `is_not_unique_relationship`
 * `is_unique_relationship`
+* `is_not_valid_relationship`
+* `is_valid_relationship`
+* `is_not_valid_reference`
+* `is_valid_reference`
 
 ### Returning data to your client
 

--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.15'
+__version__ = '1.0.16'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -759,7 +759,6 @@ class DataframeType(BaseType):
         target = self.replace_prefix(other_value.get("target"))
         value_column = self.replace_prefix(other_value.get("comparator"))
         results = self.value.apply(lambda row: self.detect_reference(row, value_column, target), axis=1)
-        print(results)
         self.value[f"result_{uuid4()}"] = results
         return not(False in results.values)
 

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -263,6 +263,7 @@ class DataframeType(BaseType):
     def __init__(self, data):
         self.value = self._assert_valid_value_and_cast(data["value"])
         self.column_prefix_map = data.get("column_prefix_map", {})
+        self.relationship_data = data.get("relationship_data", {})
 
     def _assert_valid_value_and_cast(self, value):
         if not hasattr(value, '__iter__'):
@@ -739,6 +740,41 @@ class DataframeType(BaseType):
         self.value[f"result_{uuid4()}"] = results
         return True in results
 
+    @type_operator(FIELD_DATAFRAME)
+    def is_valid_reference(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        results = self.value[target].isin(self.relationship_data)
+        self.value[f"result_{uuid4()}"] = results
+        return not(False in results.values)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_valid_reference(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        results = ~self.value[target].isin(self.relationship_data)
+        self.value[f"result_{uuid4()}"] = results
+        return True in results.values
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_valid_relationship(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_column = self.replace_prefix(other_value.get("comparator"))
+        results = self.value.apply(lambda row: self.detect_reference(row, value_column, target), axis=1)
+        print(results)
+        self.value[f"result_{uuid4()}"] = results
+        return not(False in results.values)
+
+    @type_operator(FIELD_DATAFRAME)
+    def is_not_valid_relationship(self, other_value):
+        target = self.replace_prefix(other_value.get("target"))
+        value_column = self.replace_prefix(other_value.get("comparator"))
+        results = ~self.value.apply(lambda row: self.detect_reference(row, value_column, target), axis=1)
+        self.value[f"result_{uuid4()}"] = results
+        return True in results.values
+
+    def detect_reference(self, row, value_column, target_column):
+        target_data = self.relationship_data.get(row[target_column], pd.Series([]).values)
+        value = row[value_column]
+        return (value in target_data) or (value in target_data.astype(int).astype(str)) or (value in target_data.astype(str))
 
 @export_type
 class GenericType(SelectMultipleType, SelectType, StringType, NumericType, BooleanType):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1120,6 +1120,82 @@ class DataframeOperatorTests(TestCase):
             DataframeType({"value": df}).non_empty_within_except_last_row({"target": "invalid", "comparator": "USUBJID"})
         )
 
+    def test_is_valid_reference(self):
+        reference_data = {
+            "TEST": [],
+            "DATA": [1,2,3]
+        }
+        df = pandas.DataFrame.from_dict(
+            {
+                "IDVAR1": ["TEST", "DATA"],
+                "IDVAR2": ["TEST", "COOL"]
+            }
+        )
+        self.assertTrue(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_valid_reference({"target": "IDVAR1"})
+        )
+        self.assertFalse(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_valid_reference({"target": "IDVAR2"})
+        )
+
+    def test_not_valid_reference(self):
+        reference_data = {
+            "TEST": [],
+            "DATA": [1,2,3]
+        }
+        df = pandas.DataFrame.from_dict(
+            {
+                "IDVAR1": ["TEST", "DATA"],
+                "IDVAR2": ["TEST", "COOL"]
+            }
+        )
+        self.assertFalse(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_not_valid_reference({"target": "IDVAR1"})
+        )
+        self.assertTrue(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_not_valid_reference({"target": "IDVAR2"})
+        )
+
+    def test_is_valid_relationship(self):
+        reference_data = {
+            "TEST": pandas.Series([4,5,6]).values,
+            "DATA": pandas.Series([1,2,3]).values
+        }
+        df = pandas.DataFrame.from_dict(
+            {
+                "IDVAR1": ["TEST", "DATA"],
+                "IDVAR2": ["TEST", "DATA"],
+                "IDVARVAL1": [4, 1],
+                "IDVARVAL2": [5, 31]
+            }
+        )
+        self.assertTrue(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_valid_relationship({"target": "IDVAR1", "comparator": "IDVARVAL1"})
+        )
+        self.assertFalse(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_valid_relationship({"target": "IDVAR2", "comparator": "IDVARVAL2"})
+        )
+
+    def test_not_valid_relationship(self):
+        reference_data = {
+            "TEST": pandas.Series([4,5,6]).values,
+            "DATA": pandas.Series([1,2,3]).values
+        }
+        df = pandas.DataFrame.from_dict(
+            {
+                "IDVAR1": ["TEST", "DATA"],
+                "IDVAR2": ["TEST", "DATA"],
+                "IDVARVAL1": [4, 1],
+                "IDVARVAL2": [5, 31]
+            }
+        )
+        self.assertFalse(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_not_valid_relationship({"target": "IDVAR1", "comparator": "IDVARVAL1"})
+        )
+        self.assertTrue(
+            DataframeType({"value": df, "relationship_data": reference_data}).is_not_valid_relationship({"target": "IDVAR2", "comparator": "IDVARVAL2"})
+        )
+
 class GenericOperatorTests(TestCase):
     def test_shares_no_elements_with(self):
         self.assertTrue(GenericType([1, 2]).


### PR DESCRIPTION
This PR adds relationship and reference checks to the dataframe operator.

Reference checks -> check if a dataframe references a column in the provided reference data
Relationship checks -> check if the value referenced appears in the specified reference column