### PR TITLE
Add value level metadata conformance check operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ Note: to compare floating point equality we just check that the difference is le
 * `is_valid_relationship`
 * `is_not_valid_reference`
 * `is_valid_reference`
+* `non_conformant_value_data_type`
+* `conformant_value_data_type`
+* `non_conformant_value_length`
+* `conformant_value_length`
 
 ### Returning data to your client
 

--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.21'
+__version__ = '1.0.22'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.20'
+__version__ = '1.0.21'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1293,6 +1293,106 @@ class DataframeOperatorTests(TestCase):
                 .equals(pandas.Series([False, False, True]))
         )
 
+    def test_non_conformant_value_length(self):
+        def filter_func(row):
+            return row["IDVAR1"] == "TEST"
+        
+        def length_check(row):
+            return len(row["IDVAR2"]) <= 4
+
+        df = pandas.DataFrame.from_dict(
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "IDVAR1": ["TEST", "TEST", "AETERM"],
+                "IDVAR2": ["TEST", "TOOLONG", "AETERM"],
+            }
+        )
+
+        vlm = [
+            {
+                "filter": filter_func,
+                "length_check": length_check
+            }
+        ]
+
+        result = DataframeType({"value": df, "value_level_metadata": vlm }).non_comformant_value_length({})
+        self.assertTrue(result.equals(pandas.Series([False, True, False])))
+
+    def test_non_conformant_value_data_type(self):
+        def filter_func(row):
+            return row["IDVAR1"] == "TEST"
+        
+        def type_check(row):
+            return isinstance(row["IDVAR2"], str)
+
+        df = pandas.DataFrame.from_dict(
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "IDVAR1": ["TEST", "TEST", "AETERM"],
+                "IDVAR2": ["TEST", 1, "AETERM"],
+            }
+        )
+
+        vlm = [
+            {
+                "filter": filter_func,
+                "type_check": type_check
+            }
+        ]
+
+        result = DataframeType({"value": df, "value_level_metadata": vlm }).non_comformant_value_data_type({})
+        self.assertTrue(result.equals(pandas.Series([False, True, False])))
+
+    def test_conformant_value_length(self):
+        def filter_func(row):
+            return row["IDVAR1"] == "TEST"
+        
+        def length_check(row):
+            return len(row["IDVAR2"]) <= 4
+
+        df = pandas.DataFrame.from_dict(
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "IDVAR1": ["TEST", "TEST", "AETERM"],
+                "IDVAR2": ["TEST", "TOOLONG", "AETERM"],
+            }
+        )
+
+        vlm = [
+            {
+                "filter": filter_func,
+                "length_check": length_check
+            }
+        ]
+
+        result = DataframeType({"value": df, "value_level_metadata": vlm }).comformant_value_length({})
+        self.assertTrue(result.equals(pandas.Series([True, False, False])))
+
+    def test_conformant_value_data_type(self):
+        def filter_func(row):
+            return row["IDVAR1"] == "TEST"
+        
+        def type_check(row):
+            return isinstance(row["IDVAR2"], str)
+
+        df = pandas.DataFrame.from_dict(
+            {
+                "RDOMAIN": ["LB", "LB", "AE"],
+                "IDVAR1": ["TEST", "TEST", "AETERM"],
+                "IDVAR2": ["TEST", 1, "AETERM"],
+            }
+        )
+
+        vlm = [
+            {
+                "filter": filter_func,
+                "type_check": type_check
+            }
+        ]
+
+        result = DataframeType({"value": df, "value_level_metadata": vlm }).comformant_value_data_type({})
+        self.assertTrue(result.equals(pandas.Series([True, False, False])))
+
 class GenericOperatorTests(TestCase):
     def test_shares_no_elements_with(self):
         self.assertTrue(GenericType([1, 2]).


### PR DESCRIPTION
This PR adds value level metadata conformance check operators for checking data type and length conform with value level metadata. 

This works by providing value level metadata containing a filter function for filtering data to only rows for which the value level metadata applies, and then providing a check function (either type or length) for validating the type and length of the variable in the row conforms to the restrictions of the function. This allows us to provide arbitrary checking logic based on a users value level metadata