### PR TITLE
Add flag for explicit string checks

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.24'
+__version__ = '1.0.25'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -292,6 +292,12 @@ class DataframeType(BaseType):
         for i in range(len(values)):
             values[i] = self.replace_prefix(values[i])
         return values
+    
+    def get_comparator_data(self, comparator, use_explicit_value: bool = False):
+        if use_explicit_value:
+            return comparator
+        else:
+            return self.value.get(comparator, comparator)
 
     @type_operator(FIELD_DATAFRAME)
     def exists(self, other_value):
@@ -305,15 +311,18 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def equal_to(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        comparator = self.replace_prefix(other_value.get("comparator"))
-        results = np.where(self.value.get(target) == self.value.get(comparator, comparator), True, False)
+        use_explicit_value = other_value.get("use_explicit_value", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        results = np.where(self.value.get(target) == comparison_data, True, False)
         return pd.Series(results)
 
     @type_operator(FIELD_DATAFRAME)
     def equal_to_case_insensitive(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        comparator = self.replace_prefix(other_value.get("comparator"))
-        comparison_data = self.value.get(comparator, comparator)
+        use_explicit_value = other_value.get("use_explicit_value", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         results = np.where(self.value.get(target).str.lower() == comparison_data, True, False)
         return pd.Series(results)
@@ -337,26 +346,31 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def greater_than_or_equal_to(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        comparator = self.replace_prefix(other_value.get("comparator"))
-        results = np.where(self.value.get(target) >= self.value.get(comparator, comparator), True, False)
+        use_explicit_value = other_value.get("use_explicit_value", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        results = np.where(self.value.get(target) >= comparison_data, True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
     def greater_than(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        comparator = self.replace_prefix(other_value.get("comparator"))
-        results = np.where(self.value.get(target) > self.value.get(comparator, comparator), True, False)
+        use_explicit_value = other_value.get("use_explicit_value", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        results = np.where(self.value.get(target) > comparison_data, True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
     def contains(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        comparator = self.replace_prefix(other_value.get("comparator"))
-        comparison_value = self.value.get(comparator, comparator)
+        use_explicit_value = other_value.get("use_explicit_value", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
         if isinstance(comparator, pandas.core.series.Series):
-            results = np.where(comparison_value.isin(self.value[target]), True, False)
+            results = np.where(comparison_data.isin(self.value[target]), True, False)
         else:
-            results = np.where(self.value[target] == comparison_value, True, False)
+            results = np.where(self.value[target] == comparison_data, True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
@@ -366,8 +380,9 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def contains_case_insensitive(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        comparator = self.replace_prefix(other_value.get("comparator"))
-        comparison_data = self.value.get(comparator, comparator)
+        use_explicit_value = other_value.get("use_explicit_value", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         if isinstance(comparator, pandas.core.series.Series):
             results = np.where(comparison_data.isin(self.value[target].str.lower()), True, False)
@@ -382,11 +397,13 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def is_contained_by(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
+        use_explicit_value = other_value.get("use_explicit_value", False)
         comparator = other_value.get("comparator")
-        if isinstance(comparator, str):
+        if isinstance(comparator, str) and not use_explicit_value:
             # column name provided
             comparator = self.replace_prefix(comparator)
-        results = self.value[target].isin(self.value.get(comparator, comparator))
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        results = self.value[target].isin(comparison_data)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
@@ -397,12 +414,13 @@ class DataframeType(BaseType):
     def is_contained_by_case_insensitive(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator", [])
+        use_explicit_value = other_value.get("use_explicit_value", False)
         if isinstance(comparator, list):
             comparator = [val.lower() for val in comparator]
-        elif isinstance(comparator, str):
+        elif isinstance(comparator, str) and not use_explicit_value:
             # column name provided
             comparator = self.replace_prefix(comparator)
-        comparison_data = self.value.get(comparator, comparator)
+        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
         if isinstance(comparison_data, pd.core.series.Series):
             comparison_data = comparison_data.str.lower()
         results = self.value[target].str.lower().isin(comparison_data)

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -293,8 +293,8 @@ class DataframeType(BaseType):
             values[i] = self.replace_prefix(values[i])
         return values
     
-    def get_comparator_data(self, comparator, use_explicit_value: bool = False):
-        if use_explicit_value:
+    def get_comparator_data(self, comparator, value_is_literal: bool = False):
+        if value_is_literal:
             return comparator
         else:
             return self.value.get(comparator, comparator)
@@ -311,18 +311,18 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def equal_to(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        use_explicit_value = other_value.get("use_explicit_value", False)
-        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         results = np.where(self.value.get(target) == comparison_data, True, False)
         return pd.Series(results)
 
     @type_operator(FIELD_DATAFRAME)
     def equal_to_case_insensitive(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        use_explicit_value = other_value.get("use_explicit_value", False)
-        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         results = np.where(self.value.get(target).str.lower() == comparison_data, True, False)
         return pd.Series(results)
@@ -346,27 +346,27 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def greater_than_or_equal_to(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        use_explicit_value = other_value.get("use_explicit_value", False)
-        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         results = np.where(self.value.get(target) >= comparison_data, True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
     def greater_than(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        use_explicit_value = other_value.get("use_explicit_value", False)
-        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         results = np.where(self.value.get(target) > comparison_data, True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
     def contains(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        use_explicit_value = other_value.get("use_explicit_value", False)
-        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         if isinstance(comparator, pandas.core.series.Series):
             results = np.where(comparison_data.isin(self.value[target]), True, False)
         else:
@@ -380,9 +380,9 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def contains_case_insensitive(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        use_explicit_value = other_value.get("use_explicit_value", False)
-        comparator = self.replace_prefix(other_value.get("comparator")) if not use_explicit_value else other_value.get("comparator")
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
         if isinstance(comparator, pandas.core.series.Series):
             results = np.where(comparison_data.isin(self.value[target].str.lower()), True, False)
@@ -397,12 +397,12 @@ class DataframeType(BaseType):
     @type_operator(FIELD_DATAFRAME)
     def is_contained_by(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
-        use_explicit_value = other_value.get("use_explicit_value", False)
+        value_is_literal = other_value.get("value_is_literal", False)
         comparator = other_value.get("comparator")
-        if isinstance(comparator, str) and not use_explicit_value:
+        if isinstance(comparator, str) and not value_is_literal:
             # column name provided
             comparator = self.replace_prefix(comparator)
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         results = self.value[target].isin(comparison_data)
         return pd.Series(results)
     
@@ -414,13 +414,13 @@ class DataframeType(BaseType):
     def is_contained_by_case_insensitive(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator", [])
-        use_explicit_value = other_value.get("use_explicit_value", False)
+        value_is_literal = other_value.get("value_is_literal", False)
         if isinstance(comparator, list):
             comparator = [val.lower() for val in comparator]
-        elif isinstance(comparator, str) and not use_explicit_value:
+        elif isinstance(comparator, str) and not value_is_literal:
             # column name provided
             comparator = self.replace_prefix(comparator)
-        comparison_data = self.get_comparator_data(comparator, use_explicit_value)
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
         if isinstance(comparison_data, pd.core.series.Series):
             comparison_data = comparison_data.str.lower()
         results = self.value[target].str.lower().isin(comparison_data)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -229,7 +229,8 @@ class DataframeOperatorTests(TestCase):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
             "var2": [3,5,6],
-            "var3": [1,3,8]
+            "var3": [1,3,8],
+            "var4": ["test", "issue", "one"]
         })
         self.assertTrue(DataframeType({"value": df}).equal_to({
             "target": "var1",
@@ -250,6 +251,11 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).equal_to({
             "target": "var1",
             "comparator": 20
+        }).equals(pandas.Series([False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).equal_to({
+            "target": "var4",
+            "comparator": "var1",
+            "use_explicit_value": True
         }).equals(pandas.Series([False, False, False])))
 
     def test_not_equal_to(self):
@@ -294,9 +300,14 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var2"
         }).equals(pandas.Series([True, False, True])))
-        self.assertTrue(DataframeType({"value": df}).equal_to({
+        self.assertTrue(DataframeType({"value": df}).equal_to_case_insensitive({
             "target": "var1",
             "comparator": "var3"
+        }).equals(pandas.Series([False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).equal_to_case_insensitive({
+            "target": "var1",
+            "comparator": "var1",
+            "use_explicit_value": True
         }).equals(pandas.Series([False, False, False])))
 
     def test_not_equal_to_case_insensitive(self):
@@ -314,6 +325,11 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var2"
         }).equals(pandas.Series([False, True, False])))
+        self.assertTrue(DataframeType({"value": df}).not_equal_to_case_insensitive({
+            "target": "var1",
+            "comparator": "var1",
+            "use_explicit_value": True
+        }).equals(pandas.Series([True, True, True])))
 
     def test_less_than(self):
         df = pandas.DataFrame.from_dict({
@@ -428,7 +444,8 @@ class DataframeOperatorTests(TestCase):
             "var1": [1,2,4],
             "var2": [3,5,6],
             "var3": [1,3,8],
-            "var4": [1,2,4]
+            "var4": [1,2,4],
+            "string_var": ["hj", "word", "c"]
         })
         self.assertTrue(DataframeType({"value": df}).contains({
             "target": "var1",
@@ -446,13 +463,23 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var2"
         }).equals(pandas.Series([False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).contains({
+            "target": "string_var",
+            "comparator": "string_var"
+        }).equals(pandas.Series([True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).contains({
+            "target": "string_var",
+            "comparator": "string_var",
+            "use_explicit_value": True
+        }).equals(pandas.Series([False, False, False])))
 
     def test_does_not_contain(self):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
             "var2": [3,5,6],
             "var3": [1,3,8],
-            "var4": [1,2,4]
+            "var4": [1,2,4],
+            "string_var": ["hj", "word", "c"]
         })
         self.assertTrue(DataframeType({"value": df}).does_not_contain({
             "target": "var1",
@@ -470,6 +497,16 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var2"
         }).equals(pandas.Series([True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).does_not_contain({
+            "target": "string_var",
+            "comparator": "string_var",
+            "use_explicit_value": True
+        }).equals(pandas.Series([True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).does_not_contain({
+            "target": "string_var",
+            "comparator": "string_var"
+        }).equals(pandas.Series([False, False, False])))
+
 
     def test_contains_case_insensitive(self):
         df = pandas.DataFrame.from_dict({
@@ -493,6 +530,15 @@ class DataframeOperatorTests(TestCase):
             "target": "var1",
             "comparator": "var3"
         }).equals(pandas.Series([False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).contains_case_insensitive({
+            "target": "var3",
+            "comparator": "var3"
+        }).equals(pandas.Series([True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).contains_case_insensitive({
+            "target": "var3",
+            "comparator": "var3",
+            "use_explicit_value": True
+        }).equals(pandas.Series([False, False, False])))
 
     def test_does_not_contain_case_insensitive(self):
         df = pandas.DataFrame.from_dict({
@@ -507,6 +553,15 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).does_not_contain_case_insensitive({
             "target": "var3",
             "comparator": "var2"
+        }).equals(pandas.Series([False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).does_not_contain_case_insensitive({
+            "target": "var3",
+            "comparator": "var3",
+            "use_explicit_value": True
+        }).equals(pandas.Series([True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).does_not_contain_case_insensitive({
+            "target": "var3",
+            "comparator": "var3"
         }).equals(pandas.Series([False, False, False])))
 
     def test_is_contained_by(self):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -255,7 +255,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).equal_to({
             "target": "var4",
             "comparator": "var1",
-            "use_explicit_value": True
+            "value_is_literal": True
         }).equals(pandas.Series([False, False, False])))
 
     def test_not_equal_to(self):
@@ -307,7 +307,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).equal_to_case_insensitive({
             "target": "var1",
             "comparator": "var1",
-            "use_explicit_value": True
+            "value_is_literal": True
         }).equals(pandas.Series([False, False, False])))
 
     def test_not_equal_to_case_insensitive(self):
@@ -328,7 +328,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).not_equal_to_case_insensitive({
             "target": "var1",
             "comparator": "var1",
-            "use_explicit_value": True
+            "value_is_literal": True
         }).equals(pandas.Series([True, True, True])))
 
     def test_less_than(self):
@@ -470,7 +470,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).contains({
             "target": "string_var",
             "comparator": "string_var",
-            "use_explicit_value": True
+            "value_is_literal": True
         }).equals(pandas.Series([False, False, False])))
 
     def test_does_not_contain(self):
@@ -500,7 +500,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).does_not_contain({
             "target": "string_var",
             "comparator": "string_var",
-            "use_explicit_value": True
+            "value_is_literal": True
         }).equals(pandas.Series([True, True, True])))
         self.assertTrue(DataframeType({"value": df}).does_not_contain({
             "target": "string_var",
@@ -537,7 +537,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).contains_case_insensitive({
             "target": "var3",
             "comparator": "var3",
-            "use_explicit_value": True
+            "value_is_literal": True
         }).equals(pandas.Series([False, False, False])))
 
     def test_does_not_contain_case_insensitive(self):
@@ -557,7 +557,7 @@ class DataframeOperatorTests(TestCase):
         self.assertTrue(DataframeType({"value": df}).does_not_contain_case_insensitive({
             "target": "var3",
             "comparator": "var3",
-            "use_explicit_value": True
+            "value_is_literal": True
         }).equals(pandas.Series([True, True, True])))
         self.assertTrue(DataframeType({"value": df}).does_not_contain_case_insensitive({
             "target": "var3",


### PR DESCRIPTION
This PR adds the ability for rule authors to provide a flag `use_explicit_value` that bypasses the initial checks for a comparator in the provided dataframe. Instead the actual value provided is compared when a string is necessary. This is meant to support cases where the target value is the same as a column in the dataframe