### PR TITLE
Add codelist checks against provided library metadata

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.28'
+__version__ = '1.0.29'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -842,6 +842,12 @@ class DataframeType(BaseType):
     def valid_codelist_reference(self, column_name, codelist):
         if column_name in self.column_codelist_map:
             return codelist in self.column_codelist_map[column_name]
+        elif self.column_prefix_map:
+            # Check for generic versions of variables (i.e --DECOD)
+            for key in self.column_prefix_map:
+                if column_name.startswith(self.column_prefix_map[key]):
+                    generic_column_name = column_name.replace(self.column_prefix_map[key], key, 1)
+                    return codelist in self.column_codelist_map.get(generic_column_name)
         return True
     
     def valid_terms(self, codelist, terms_list):

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -267,6 +267,8 @@ class DataframeType(BaseType):
         self.column_prefix_map = data.get("column_prefix_map", {})
         self.relationship_data = data.get("relationship_data", {})
         self.value_level_metadata = data.get("value_level_metadata", [])
+        self.column_codelist_map = data.get("column_codelist_map", {})
+        self.codelist_term_map = data.get("codelist_term_map", {})
 
     def _assert_valid_value_and_cast(self, value):
         if not hasattr(value, '__iter__'):
@@ -807,6 +809,28 @@ class DataframeType(BaseType):
     def additional_columns_not_empty(self, other_value: dict):
         return ~self.additional_columns_empty(other_value)
 
+    @type_operator(FIELD_DATAFRAME)
+    def references_correct_codelist(self, other_value: dict):
+        target: str = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
+        result: pd.Series = self.value.apply(lambda row: self.valid_codelist_reference(row[target], row[comparator]), axis=1)
+        return result
+    
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_reference_correct_codelist(self, other_value: dict):
+        return ~self.references_correct_codelist(other_value)
+
+    @type_operator(FIELD_DATAFRAME)
+    def uses_valid_codelist_terms(self, other_value: dict):
+        target: str = self.replace_prefix(other_value.get("target"))
+        comparator = self.replace_prefix(other_value.get("comparator"))
+        result: pd.Series = self.value.apply(lambda row: self.valid_terms(row[target], row[comparator]), axis=1)
+        return result
+
+    @type_operator(FIELD_DATAFRAME)
+    def does_not_use_valid_codelist_terms(self, other_value: dict):
+        return ~self.uses_valid_codelist_terms(other_value)
+
     def next_column_exists_and_previous_is_null(self, row: pd.Series) -> bool:
         row.reset_index(drop=True, inplace=True)
         for index in row[row.isin([[], {}, "", None])].index:  # leaving null values only
@@ -814,6 +838,17 @@ class DataframeType(BaseType):
             if next_position < len(row) and row[next_position] is not None:
                 return True
         return False
+    
+    def valid_codelist_reference(self, column_name, codelist):
+        if column_name in self.column_codelist_map:
+            return codelist in self.column_codelist_map[column_name]
+        return True
+    
+    def valid_terms(self, codelist, terms_list):
+        if codelist in self.codelist_term_map:
+            return self.codelist_term_map[codelist].get("extensible", False) or set(terms_list).issubset(self.codelist_term_map[codelist].get("allowed_terms", []))
+        return False
+
 
     @type_operator(FIELD_DATAFRAME)
     def has_different_values(self, other_value: dict):

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -268,7 +268,7 @@ class DataframeType(BaseType):
         self.relationship_data = data.get("relationship_data", {})
         self.value_level_metadata = data.get("value_level_metadata", [])
         self.column_codelist_map = data.get("column_codelist_map", {})
-        self.codelist_term_map = data.get("codelist_term_map", {})
+        self.codelist_term_maps = data.get("codelist_term_maps", [])
 
     def _assert_valid_value_and_cast(self, value):
         if not hasattr(value, '__iter__'):
@@ -845,9 +845,11 @@ class DataframeType(BaseType):
         return True
     
     def valid_terms(self, codelist, terms_list):
-        if codelist in self.codelist_term_map:
-            return self.codelist_term_map[codelist].get("extensible", False) or set(terms_list).issubset(self.codelist_term_map[codelist].get("allowed_terms", []))
-        return False
+        valid_term = False
+        for codelist_term_map in self.codelist_term_maps:
+            if codelist in codelist_term_map:
+                valid_term = valid_term or (codelist_term_map[codelist].get("extensible") or set(terms_list).issubset(codelist_term_map[codelist].get("allowed_terms", [])))
+        return valid_term
 
 
     @type_operator(FIELD_DATAFRAME)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1662,12 +1662,15 @@ class DataframeOperatorTests(TestCase):
 
         column_codelist_map = {
             "TEST": ["C123", "C456"],
-            "COOLVAR": ["C123", "C456"],
+            "--OLVAR": ["C123", "C456"],
             "ANOTHERVAR": ["C789"]
         }
         dft = DataframeType({
             "value": df,
-            "column_codelist_map": column_codelist_map
+            "column_codelist_map": column_codelist_map,
+            "column_prefix_map": {
+                "--": "CO"
+            }
         })
 
         result = dft.does_not_reference_correct_codelist({"target": "define_variable_name", "comparator": "define_variable_controlled_terms"})

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1694,7 +1694,7 @@ class DataframeOperatorTests(TestCase):
             }
         )
 
-        extensible_codelist_term_map = {
+        extensible_codelist_term_map = [{
             "C123": {
                 "extensible": False,
                 "allowed_terms": ["A", "B", "b", "C"],
@@ -1707,9 +1707,9 @@ class DataframeOperatorTests(TestCase):
                 "extensible": False,
                 "allowed_terms": ["E", "F", "b", "C"]
             }
-        }
+        }]
 
-        codelist_term_map = {
+        codelist_term_map = [{
             "C123": {
                 "extensible": False,
                 "allowed_terms": ["A", "B", "b", "C"],
@@ -1722,10 +1722,10 @@ class DataframeOperatorTests(TestCase):
                 "extensible": False,
                 "allowed_terms": ["E", "F", "b", "C"]
             }
-        }
+        }]
         dft = DataframeType({
             "value": df,
-            "codelist_term_map": codelist_term_map
+            "codelist_term_maps": codelist_term_map
         })
 
         result = dft.uses_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_allowed_terms"})
@@ -1737,7 +1737,7 @@ class DataframeOperatorTests(TestCase):
         # Test extensible flag
         dft = DataframeType({
             "value": df,
-            "codelist_term_map": extensible_codelist_term_map
+            "codelist_term_maps": extensible_codelist_term_map
         })
         
         result = dft.uses_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_invalid_allowed_terms"})
@@ -1761,7 +1761,7 @@ class DataframeOperatorTests(TestCase):
             }
         )
 
-        extensible_codelist_term_map = {
+        extensible_codelist_term_map = [{
             "C123": {
                 "extensible": False,
                 "allowed_terms": ["A", "B", "b", "C"],
@@ -1774,9 +1774,9 @@ class DataframeOperatorTests(TestCase):
                 "extensible": False,
                 "allowed_terms": ["E", "F", "b", "C"]
             }
-        }
+        }]
 
-        codelist_term_map = {
+        codelist_term_map = [{
             "C123": {
                 "extensible": False,
                 "allowed_terms": ["A", "B", "b", "C"],
@@ -1789,10 +1789,10 @@ class DataframeOperatorTests(TestCase):
                 "extensible": False,
                 "allowed_terms": ["E", "F", "b", "C"]
             }
-        }
+        }]
         dft = DataframeType({
             "value": df,
-            "codelist_term_map": codelist_term_map
+            "codelist_term_maps": codelist_term_map
         })
 
         result = dft.does_not_use_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_allowed_terms"})
@@ -1804,7 +1804,7 @@ class DataframeOperatorTests(TestCase):
         # Test extensible flag
         dft = DataframeType({
             "value": df,
-            "codelist_term_map": extensible_codelist_term_map
+            "codelist_term_maps": extensible_codelist_term_map
         })
         
         result = dft.does_not_use_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_invalid_allowed_terms"})

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1624,6 +1624,191 @@ class DataframeOperatorTests(TestCase):
         )
         result = DataframeType({"value": df_without_empty_rows, }).additional_columns_not_empty({"target": "TSVAL", })
         self.assertTrue(result.equals(pandas.Series([True, True, True, True, ])))
+    
+    def test_references_valid_codelist(self):
+        df = pandas.DataFrame.from_dict(
+            {
+                "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR" ],
+                "define_variable_controlled_terms": ["C123", "C456", "C789"],
+                "define_variable_invalid_terms": ["C123", "C456", "C786"]
+            }
+        )
+
+        column_codelist_map = {
+            "TEST": ["C123", "C456"],
+            "COOLVAR": ["C123", "C456"],
+            "ANOTHERVAR": ["C789"]
+        }
+        dft = DataframeType({
+            "value": df,
+            "column_codelist_map": column_codelist_map
+        })
+
+        result = dft.references_correct_codelist({"target": "define_variable_name", "comparator": "define_variable_controlled_terms"})
+        self.assertTrue(result.equals(pandas.Series([True, True, True ])))
+        
+        bad_result = dft.references_correct_codelist({"target": "define_variable_name", "comparator": "define_variable_invalid_terms"})
+        self.assertTrue(bad_result.equals(pandas.Series([True, True, False])))
+
+
+    def test_does_not_reference_valid_codelist(self):
+        df = pandas.DataFrame.from_dict(
+            {
+                "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR" ],
+                "define_variable_controlled_terms": ["C123", "C456", "C789"],
+                "define_variable_invalid_terms": ["C123", "C456", "C786"]
+            }
+        )
+
+        column_codelist_map = {
+            "TEST": ["C123", "C456"],
+            "COOLVAR": ["C123", "C456"],
+            "ANOTHERVAR": ["C789"]
+        }
+        dft = DataframeType({
+            "value": df,
+            "column_codelist_map": column_codelist_map
+        })
+
+        result = dft.does_not_reference_correct_codelist({"target": "define_variable_name", "comparator": "define_variable_controlled_terms"})
+        self.assertTrue(result.equals(pandas.Series([False, False, False ])))
+        
+        bad_result = dft.does_not_reference_correct_codelist({"target": "define_variable_name", "comparator": "define_variable_invalid_terms"})
+        self.assertTrue(bad_result.equals(pandas.Series([False, False, True])))
+
+    def test_uses_valid_codelist_terms(self):
+        df = pandas.DataFrame.from_dict(
+            {
+                "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR" ],
+                "define_variable_controlled_terms": ["C123", "C456", "C789"],
+                "define_variable_allowed_terms": [
+                    ["A", "B"],
+                    ["C", "D"],
+                    ["E", "F"]
+                ],
+                "define_variable_invalid_allowed_terms": [
+                    ["A", "L"],
+                    ["C", "Z"],
+                    ["E", "F"]
+                ]
+            }
+        )
+
+        extensible_codelist_term_map = {
+            "C123": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C"],
+            },
+            "C456": {
+                "extensible": True,
+                "allowed_terms": ["A", "B", "b", "C", "D"]
+            },
+            "C789": {
+                "extensible": False,
+                "allowed_terms": ["E", "F", "b", "C"]
+            }
+        }
+
+        codelist_term_map = {
+            "C123": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C"],
+            },
+            "C456": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C", "D"]
+            },
+            "C789": {
+                "extensible": False,
+                "allowed_terms": ["E", "F", "b", "C"]
+            }
+        }
+        dft = DataframeType({
+            "value": df,
+            "codelist_term_map": codelist_term_map
+        })
+
+        result = dft.uses_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_allowed_terms"})
+        self.assertTrue(result.equals(pandas.Series([True, True, True])))
+        
+        bad_result = dft.uses_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_invalid_allowed_terms"})
+        self.assertTrue(bad_result.equals(pandas.Series([False, False, True])))
+
+        # Test extensible flag
+        dft = DataframeType({
+            "value": df,
+            "codelist_term_map": extensible_codelist_term_map
+        })
+        
+        result = dft.uses_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_invalid_allowed_terms"})
+        self.assertTrue(result.equals(pandas.Series([False, True, True])))
+
+    def test_does_not_use_valid_terms(self):
+        df = pandas.DataFrame.from_dict(
+            {
+                "define_variable_name": ["TEST", "COOLVAR", "ANOTHERVAR" ],
+                "define_variable_controlled_terms": ["C123", "C456", "C789"],
+                "define_variable_allowed_terms": [
+                    ["A", "B"],
+                    ["C", "D"],
+                    ["E", "F"]
+                ],
+                "define_variable_invalid_allowed_terms": [
+                    ["A", "L"],
+                    ["C", "Z"],
+                    ["E", "F"]
+                ]
+            }
+        )
+
+        extensible_codelist_term_map = {
+            "C123": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C"],
+            },
+            "C456": {
+                "extensible": True,
+                "allowed_terms": ["A", "B", "b", "C", "D"]
+            },
+            "C789": {
+                "extensible": False,
+                "allowed_terms": ["E", "F", "b", "C"]
+            }
+        }
+
+        codelist_term_map = {
+            "C123": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C"],
+            },
+            "C456": {
+                "extensible": False,
+                "allowed_terms": ["A", "B", "b", "C", "D"]
+            },
+            "C789": {
+                "extensible": False,
+                "allowed_terms": ["E", "F", "b", "C"]
+            }
+        }
+        dft = DataframeType({
+            "value": df,
+            "codelist_term_map": codelist_term_map
+        })
+
+        result = dft.does_not_use_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_allowed_terms"})
+        self.assertTrue(result.equals(pandas.Series([False, False, False])))
+        
+        bad_result = dft.does_not_use_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_invalid_allowed_terms"})
+        self.assertTrue(bad_result.equals(pandas.Series([True, True, False])))
+
+        # Test extensible flag
+        dft = DataframeType({
+            "value": df,
+            "codelist_term_map": extensible_codelist_term_map
+        })
+        
+        result = dft.does_not_use_valid_codelist_terms({"target": "define_variable_controlled_terms", "comparator": "define_variable_invalid_allowed_terms"})
+        self.assertTrue(result.equals(pandas.Series([True, False, False])))
 
     def test_has_different_values(self):
         valid_df = pandas.DataFrame.from_dict(


### PR DESCRIPTION
This PR adds two new operator pairs:

`uses_valid_codelist_terms & does_not_use_valid_codelist_terms`: These operators determine whether or not the terms specified in the comparator column match the allowed terms for the codelist specified in the target column. To support this the CORE platform will need to provide a map in the following format for each codelist in a referenced CT package:
```
{
  "CODELIST CCODE": {
     "extensible": <True|False>,
     "allowed_terms": [terms allowed by the codelist]
  }...
}
```


`references_correct_codelist & does_not_reference_correct_codelist`: These operators determine whether or not the codelist referenced by a variable in a study is an applicable codelist according to the CDISC metadata. To support this the CORE platform will need to provide a map in the following format for each variable in a referenced standard version:

{
  "Variable Name": [applicable codelists]
}


