### PR TITLE
If an 'any' condition cannot find a variable in a dataframe, it shoul…

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.31'
+__version__ = '1.1.0'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -44,8 +44,11 @@ def check_conditions_recursively(conditions, defined_variables):
         assert len(conditions['any']) >= 1
         for condition in conditions['any']:
             # Always check all conditions in the case that we are operating on a dataframe
-            check_result = check_conditions_recursively(condition, defined_variables)
-            result = check_result | result
+            try:
+                check_result = check_conditions_recursively(condition, defined_variables)
+                result = check_result | result
+            except KeyError as e:
+                continue
         return result
 
     else:

--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -42,13 +42,17 @@ def check_conditions_recursively(conditions, defined_variables):
     elif keys == ['any']:
         result = False
         assert len(conditions['any']) >= 1
+        missing_variables = []
         for condition in conditions['any']:
             # Always check all conditions in the case that we are operating on a dataframe
             try:
                 check_result = check_conditions_recursively(condition, defined_variables)
                 result = check_result | result
             except KeyError as e:
-                continue
+                missing_variables.append(e.args[0])
+        if len(missing_variables) == len(conditions["any"]):
+            # Raise a key error only if all conditions in an "any" condition result in a KeyError
+            raise KeyError(", ".join(list(set(missing_variables))))
         return result
 
     else:

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -316,7 +316,7 @@ class DataframeType(BaseType):
         value_is_literal = other_value.get("value_is_literal", False)
         comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
         comparison_data = self.get_comparator_data(comparator, value_is_literal)
-        results = np.where(self.value.get(target) == comparison_data, True, False)
+        results = np.where(self.value[target] == comparison_data, True, False)
         return pd.Series(results)
 
     @type_operator(FIELD_DATAFRAME)
@@ -326,7 +326,7 @@ class DataframeType(BaseType):
         comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
         comparison_data = self.get_comparator_data(comparator, value_is_literal)
         comparison_data = self.convert_string_data_to_lower(comparison_data)
-        results = np.where(self.value.get(target).str.lower() == comparison_data, True, False)
+        results = np.where(self.value[target].str.lower() == comparison_data, True, False)
         return pd.Series(results)
 
     @type_operator(FIELD_DATAFRAME)
@@ -351,7 +351,7 @@ class DataframeType(BaseType):
         value_is_literal = other_value.get("value_is_literal", False)
         comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
         comparison_data = self.get_comparator_data(comparator, value_is_literal)
-        results = np.where(self.value.get(target) >= comparison_data, True, False)
+        results = np.where(self.value[target] >= comparison_data, True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
@@ -360,7 +360,7 @@ class DataframeType(BaseType):
         value_is_literal = other_value.get("value_is_literal", False)
         comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
         comparison_data = self.get_comparator_data(comparator, value_is_literal)
-        results = np.where(self.value.get(target) > comparison_data, True, False)
+        results = np.where(self.value[target] > comparison_data, True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
@@ -574,7 +574,7 @@ class DataframeType(BaseType):
         target = self.replace_prefix(other_value.get("target"))
         comparator = self.replace_prefix(other_value.get("comparator"))
         component = other_value.get("date_component")
-        results = np.where(operator(vectorized_date_component(component, self.value.get(target)), vectorized_date_component(component, self.value.get(comparator, comparator))), True, False)
+        results = np.where(operator(vectorized_date_component(component, self.value[target]), vectorized_date_component(component, self.value.get(comparator, comparator))), True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -1,5 +1,5 @@
 from business_rules import engine
-from business_rules.variables import BaseVariables
+from business_rules.variables import BaseVariables, dataframe_rule_variable
 from business_rules.operators import StringType
 from business_rules.actions import BaseActions
 
@@ -191,3 +191,21 @@ class EngineTests(TestCase):
         err_string = "Action fakeone is not defined in class BaseActions"
         with self.assertRaisesRegexp(AssertionError, err_string):
             engine.do_actions(actions, BaseActions())
+
+    def test_any_condition_missing_columns(self):
+        conditions = {'any': [{
+            'name': "get_dataset",
+            "operator": "starts_with",
+            "value": {
+                "target": "invalid",
+                "comparator": "HE"
+            }
+        }]}
+
+        class DatasetVariables(BaseVariables):
+            @dataframe_rule_variable()
+            def get_dataset(): return {"value": {"TEST": "NE"}}
+
+        variables = DatasetVariables()
+        result = engine.check_conditions_recursively(conditions, DatasetVariables)
+        assert result == False

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -193,19 +193,57 @@ class EngineTests(TestCase):
             engine.do_actions(actions, BaseActions())
 
     def test_any_condition_missing_columns(self):
-        conditions = {'any': [{
-            'name': "get_dataset",
-            "operator": "starts_with",
-            "value": {
-                "target": "invalid",
-                "comparator": "HE"
+        conditions = {'any': [
+            {
+                'name': "get_dataset",
+                "operator": "starts_with",
+                "value": {
+                    "target": "invalid",
+                    "comparator": "HE"
+                }
+            },
+            {
+                'name': "get_dataset",
+                "operator": "less_than",
+                "value": {
+                    "target": "TEST",
+                    "comparator": 1
+                }
             }
-        }]}
+            ]}
 
         class DatasetVariables(BaseVariables):
             @dataframe_rule_variable()
-            def get_dataset(): return {"value": {"TEST": "NE"}}
+            def get_dataset(): return {"value": {"TEST": 2}}
 
         variables = DatasetVariables()
         result = engine.check_conditions_recursively(conditions, DatasetVariables)
-        assert result == False
+        assert result[0] == False
+
+    def test_any_condition_all_conditions_reference_missing_columns(self):
+        conditions = {'any': [
+            {
+                'name': "get_dataset",
+                "operator": "starts_with",
+                "value": {
+                    "target": "invalid",
+                    "comparator": "HE"
+                }
+            },
+            {
+                'name': "get_dataset",
+                "operator": "less_than",
+                "value": {
+                    "target": "invalid",
+                    "comparator": 1
+                }
+            }
+            ]}
+
+        class DatasetVariables(BaseVariables):
+            @dataframe_rule_variable()
+            def get_dataset(): return {"value": {"TEST": 2}}
+
+        variables = DatasetVariables()
+        with self.assertRaisesRegexp(KeyError, "invalid"):
+            result = engine.check_conditions_recursively(conditions, DatasetVariables)

--- a/tests/test_engine_logic.py
+++ b/tests/test_engine_logic.py
@@ -214,10 +214,10 @@ class EngineTests(TestCase):
 
         class DatasetVariables(BaseVariables):
             @dataframe_rule_variable()
-            def get_dataset(): return {"value": {"TEST": 2}}
+            def get_dataset(self): return {"value": {"TEST": 2}}
 
         variables = DatasetVariables()
-        result = engine.check_conditions_recursively(conditions, DatasetVariables)
+        result = engine.check_conditions_recursively(conditions, variables)
         assert result[0] == False
 
     def test_any_condition_all_conditions_reference_missing_columns(self):
@@ -242,8 +242,8 @@ class EngineTests(TestCase):
 
         class DatasetVariables(BaseVariables):
             @dataframe_rule_variable()
-            def get_dataset(): return {"value": {"TEST": 2}}
+            def get_dataset(self): return {"value": {"TEST": 2}}
 
         variables = DatasetVariables()
         with self.assertRaisesRegexp(KeyError, "invalid"):
-            result = engine.check_conditions_recursively(conditions, DatasetVariables)
+            result = engine.check_conditions_recursively(conditions, variables)


### PR DESCRIPTION
This PR addresses the concern that, when a variable referenced in an any condition is missing from the dataset, the rule will result in an execution error. Instead this should be ignored. 

This PR also addresses an issue where for some operators, if the target was not in the dataset, the engine produced a cryptic error message due to attempting to execute the operator on None. Now the engine will throw a KeyError for these operators when the variable is missing