### PR TITLE
Handle comparison with None

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -339,11 +339,21 @@ class DataframeType(BaseType):
     
     @type_operator(FIELD_DATAFRAME)
     def less_than(self, other_value):
-        return ~self.greater_than_or_equal_to(other_value)
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        results = np.where(self.value[target] < comparison_data, True, False)
+        return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
     def less_than_or_equal_to(self, other_value):
-        return ~self.greater_than(other_value)
+        target = self.replace_prefix(other_value.get("target"))
+        value_is_literal = other_value.get("value_is_literal", False)
+        comparator = self.replace_prefix(other_value.get("comparator")) if not value_is_literal else other_value.get("comparator")
+        comparison_data = self.get_comparator_data(comparator, value_is_literal)
+        results = np.where(self.value[target] <= comparison_data, True, False)
+        return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)
     def greater_than_or_equal_to(self, other_value):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -359,6 +359,16 @@ class DataframeOperatorTests(TestCase):
             "comparator": 3
         }).equals(pandas.Series([True, True, False])))
 
+        another_df = pandas.DataFrame.from_dict(
+            {
+                "LBDY": [4, None, None, None, None]
+            }
+        )
+        self.assertTrue(DataframeType({"value": another_df}).less_than({
+            "target": "LBDY",
+            "comparator": 5
+        }).equals(pandas.Series([True, False, False, False, False, ])))
+
     def test_less_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
@@ -386,6 +396,16 @@ class DataframeOperatorTests(TestCase):
             "target": "var2",
             "comparator": "var3"
         }).equals(pandas.Series([False, False, True])))
+
+        another_df = pandas.DataFrame.from_dict(
+            {
+                "LBDY": [4, 5, None, None, None]
+            }
+        )
+        self.assertTrue(DataframeType({"value": another_df}).less_than_or_equal_to({
+            "target": "LBDY",
+            "comparator": 5
+        }).equals(pandas.Series([True, True, False, False, False, ])))
 
     def test_greater_than(self):
         df = pandas.DataFrame.from_dict({
@@ -415,6 +435,16 @@ class DataframeOperatorTests(TestCase):
             "comparator": 5000
         }).equals(pandas.Series([False, False, False])))
 
+        another_df = pandas.DataFrame.from_dict(
+            {
+                "LBDY": [4, None, None, None, None]
+            }
+        )
+        self.assertTrue(DataframeType({"value": another_df}).greater_than({
+            "target": "LBDY",
+            "comparator": 3
+        }).equals(pandas.Series([True, False, False, False, False, ])))
+
     def test_greater_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict({
             "var1": [1,2,4],
@@ -438,6 +468,16 @@ class DataframeOperatorTests(TestCase):
             "target": "var2",
             "comparator": 2
         }).equals(pandas.Series([True, True, True])))
+
+        another_df = pandas.DataFrame.from_dict(
+            {
+                "LBDY": [4, 3, None, None, None]
+            }
+        )
+        self.assertTrue(DataframeType({"value": another_df}).greater_than_or_equal_to({
+            "target": "LBDY",
+            "comparator": 3
+        }).equals(pandas.Series([True, True, False, False, False, ])))
 
     def test_contains(self):
         df = pandas.DataFrame.from_dict({


### PR DESCRIPTION
The problem with using ~ in less_than is that it handles None values incorrectly.

Example:
dataset:
0      4.0
1     None
2     None
3     None
4     None

operator: less_than 5
expected: True in 0 row, False in others

result (using ~ sign):
0    True
1     True
2     True
3     True
4     True

result (using the fix):
0    True
1     False
2     False
3     False
4     False

@nhaydel how do you think are there operators that I could miss?