### PR TITLE
Update date comparison to ignore None or empty string

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.3'
+__version__ = '1.1.4'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -11,7 +11,7 @@ from .six import string_types, integer_types
 
 from .fields import (FIELD_DATAFRAME, FIELD_TEXT, FIELD_NUMERIC, FIELD_NO_INPUT,
                      FIELD_SELECT, FIELD_SELECT_MULTIPLE)
-from .utils import fn_name_to_pretty_label, float_to_decimal, vectorized_is_valid, vectorized_date_component, \
+from .utils import fn_name_to_pretty_label, float_to_decimal, vectorized_is_valid, vectorized_compare_dates, \
     vectorized_is_complete_date, vectorized_len, vectorized_get_dict_key, vectorized_is_in, vectorized_case_insensitive_is_in
 from decimal import Decimal, Inexact, Context
 import operator
@@ -598,7 +598,7 @@ class DataframeType(BaseType):
         target = self.replace_prefix(other_value.get("target"))
         comparator = self.replace_prefix(other_value.get("comparator"))
         component = other_value.get("date_component")
-        results = np.where(operator(vectorized_date_component(component, self.value[target]), vectorized_date_component(component, self.value.get(comparator, comparator))), True, False)
+        results = np.where(vectorized_compare_dates(component, self.value[target], self.value.get(comparator, comparator), operator), True, False)
         return pd.Series(results)
     
     @type_operator(FIELD_DATAFRAME)

--- a/business_rules/utils.py
+++ b/business_rules/utils.py
@@ -126,8 +126,15 @@ def is_in(value, values):
 def case_insensitive_is_in(value, values):
     return value in map(str.lower, values)
 
+def compare_dates(component, target, comparator, operator):
+    if not target or not comparator:
+        # Comparison should return false if either is empty or None
+        return False
+    else:
+        return operator(get_date_component(component, target), get_date_component(component, comparator))
+
 vectorized_is_complete_date = np.vectorize(is_complete_date)
-vectorized_date_component = np.vectorize(get_date_component)
+vectorized_compare_dates = np.vectorize(compare_dates)
 vectorized_is_valid = np.vectorize(is_valid_date)
 vectorized_get_dict_key = np.vectorize(get_dict_key_val)
 vectorized_is_in = np.vectorize(is_in)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1008,7 +1008,8 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var4": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var5": ["1997-08", "1997-08-16", "1997-08-16T19:20:30.45+01:00", "1997-08-16T19:20:30+01:00", "1997-08-16T19:20+01:00"],
-                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
+                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"],
+                "var7": ["", None, "", "", ""]
             }
         )
         self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var1", "comparator": '2021'})
@@ -1035,6 +1036,10 @@ class DataframeOperatorTests(TestCase):
             .equals(pandas.Series([False, False, False, False, False])))
         self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var6", "date_component": "month"})
             .equals(pandas.Series([False, False, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var3", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_equal_to({"target": "var7", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
     
     def test_date_not_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -1044,7 +1049,8 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var4": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var5": ["1997-08", "1997-08-16", "1997-08-16T19:20:30.45+01:00", "1997-08-16T19:20:30+01:00", "1997-08-16T19:20+01:00"],
-                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
+                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"],
+                "var7": ["", None, "", "", ""]
             }
         )
         self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var1", "comparator": '2022'})
@@ -1057,6 +1063,10 @@ class DataframeOperatorTests(TestCase):
             .equals(pandas.Series([False, False, False, False, False])))
         self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var6", "date_component": "hour"})
             .equals(pandas.Series([False, False, True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var3", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_not_equal_to({"target": "var7", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
     
     def test_date_less_than(self):
         df = pandas.DataFrame.from_dict(
@@ -1066,7 +1076,8 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var4": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var5": ["1997-08", "1997-08-16", "1997-08-16T19:20:30.45+01:00", "1997-08-16T19:20:30+01:00", "1997-08-16T19:20+01:00"],
-                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
+                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"],
+                "var7": ["", None, "", "", ""]
             }
         )
         self.assertTrue(DataframeType({"value": df}).date_less_than({"target": "var1", "comparator": '2022'})
@@ -1079,6 +1090,10 @@ class DataframeOperatorTests(TestCase):
             .equals(pandas.Series([False, False, False, False, False])))
         self.assertTrue(DataframeType({"value": df}).date_less_than({"target": "var3", "comparator": "var6", "date_component": "hour"})
             .equals(pandas.Series([False, False, True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).date_less_than({"target": "var3", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_less_than({"target": "var7", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
 
     def test_date_greater_than(self):
         df = pandas.DataFrame.from_dict(
@@ -1088,7 +1103,8 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var4": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var5": ["1997-08", "1997-08-16", "1997-08-16T19:20:30.45+01:00", "1997-08-16T19:20:30+01:00", "1997-08-16T19:20+01:00"],
-                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
+                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"],
+                "var7": ["", None, "", "", ""]
             }
         )
         self.assertTrue(DataframeType({"value": df}).date_greater_than({"target": "var1", "comparator": '2020'})
@@ -1101,6 +1117,10 @@ class DataframeOperatorTests(TestCase):
             .equals(pandas.Series([False, False, False, False, False])))
         self.assertTrue(DataframeType({"value": df}).date_greater_than({"target": "var6", "comparator": "var3", "date_component": "hour"})
             .equals(pandas.Series([False, False, True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than({"target": "var3", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than({"target": "var7", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
     
     def test_date_greater_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -1110,7 +1130,8 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var4": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var5": ["1997-08", "1997-08-16", "1997-08-16T19:20:30.45+01:00", "1997-08-16T19:20:30+01:00", "1997-08-16T19:20+01:00"],
-                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
+                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"],
+                "var7": ["", None, "", "", ""]
             }
         )
         self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var1", "comparator": '2020'})
@@ -1125,6 +1146,10 @@ class DataframeOperatorTests(TestCase):
             .equals(pandas.Series([True, True, True, True, True])))
         self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var6", "comparator": "var3", "date_component": "hour"})
             .equals(pandas.Series([True, True, True, True, True])))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var3", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_greater_than_or_equal_to({"target": "var7", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
     
     def test_date_less_than_or_equal_to(self):
         df = pandas.DataFrame.from_dict(
@@ -1134,7 +1159,8 @@ class DataframeOperatorTests(TestCase):
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var4": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00"],
                 "var5": ["1997-08", "1997-08-16", "1997-08-16T19:20:30.45+01:00", "1997-08-16T19:20:30+01:00", "1997-08-16T19:20+01:00"],
-                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"]
+                "var6": ["1998-08", "1998-08-11", "1998-08-17T20:21:31.46+01:00", "1998-08-17T20:21:31+01:00", "1998-08-17T20:21+01:00"],
+                "var7": ["", None, "", "", ""]
             }
         )
         self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var1", "comparator": '2022'})
@@ -1149,6 +1175,10 @@ class DataframeOperatorTests(TestCase):
             .equals(pandas.Series([True, True, True, True, True])))
         self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var6", "comparator": "var3", "date_component": "hour"})
             .equals(pandas.Series([True, True, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var3", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
+        self.assertTrue(DataframeType({"value": df}).date_less_than_or_equal_to({"target": "var7", "comparator": "var7", "date_component": "month"})
+            .equals(pandas.Series([False, False, False, False, False])))
         
     def test_is_incomplete_date(self):
         df = pandas.DataFrame.from_dict(


### PR DESCRIPTION
This PR updates the date comparison operators to ignore None or empty strings as dates.