### PR TITLE
add metadata equality checks

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -1077,6 +1077,27 @@ class DataframeType(BaseType):
     def target_is_not_sorted_by(self, other_value: dict) -> pd.Series:
         return ~self.target_is_sorted_by(other_value)
 
+    @type_operator(FIELD_DATAFRAME)
+    def variable_metadata_equal_to(self, other_value: dict) -> pd.Series:
+        """
+        Validates the metadata for variables, provided in the metadata column, is equal to
+        the comparator.
+        Ex.
+        target: STUDYID
+        comparator: "Exp"
+        metadata_column: {"STUDYID": "Req", "DOMAIN": "Req"}
+        result: False       
+        """
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator") # Assumes the comparator is a value not a column
+        metadata_column = self.replace_prefix(other_value.get("metadata"))
+        result = np.where(vectorized_get_dict_key(self.value[metadata_column], target) == comparator, True, False)
+        return pd.Series(result)
+    
+    @type_operator(FIELD_DATAFRAME)
+    def variable_metadata_not_equal_to(self, other_value: dict) -> pd.Series:
+        return ~self.variable_metadata_equal_to(other_value)
+
 @export_type
 class GenericType(SelectMultipleType, SelectType, StringType, NumericType, BooleanType):
 

--- a/tests/test_dataframe_type/test_variable_metadata_equality.py
+++ b/tests/test_dataframe_type/test_variable_metadata_equality.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from . import TestCase
+from business_rules.operators import DataframeType
+
+class VariableMetadataEqualityTests(TestCase):
+    def test_variable_metadata_equal_to(self):
+        df = pd.DataFrame.from_dict({
+            "STUDYID": [1, 1, 1, 1],
+            "$CORE_VALUES": [
+                {"STUDYID": "Req", "DOMAIN": "Req"},
+                {"STUDYID": "Req", "DOMAIN": "Req"},
+                {"STUDYID": "Req", "DOMAIN": "Req"},
+                {"STUDYID": "Req", "DOMAIN": "Req"}
+            ]
+        })
+        result = DataframeType({"value": df}).variable_metadata_equal_to({"target": "STUDYID", "comparator": "Exp", "metadata": "$CORE_VALUES"})
+        self.assertTrue(result.equals(pd.Series([False, False, False, False])))
+        result = DataframeType({"value": df}).variable_metadata_equal_to({"target": "STUDYID", "comparator": "Req", "metadata": "$CORE_VALUES"})
+        self.assertTrue(result.equals(pd.Series([True, True, True, True])))
+    
+    def test_variable_metadata_equal_to(self):
+        df = pd.DataFrame.from_dict({
+            "STUDYID": [1, 1, 1, 1],
+            "$CORE_VALUES": [
+                {"STUDYID": "Req", "DOMAIN": "Req"},
+                {"STUDYID": "Req", "DOMAIN": "Req"},
+                {"STUDYID": "Req", "DOMAIN": "Req"},
+                {"STUDYID": "Req", "DOMAIN": "Req"}
+            ]
+        })
+        result = DataframeType({"value": df}).variable_metadata_not_equal_to({"target": "STUDYID", "comparator": "Exp", "metadata": "$CORE_VALUES"})
+        self.assertTrue(result.equals(pd.Series([True, True, True, True])))
+        result = DataframeType({"value": df}).variable_metadata_not_equal_to({"target": "STUDYID", "comparator": "Req", "metadata": "$CORE_VALUES"})
+        self.assertTrue(result.equals(pd.Series([False, False, False, False])))


### PR DESCRIPTION
This PR adds checks for validating the variable metadata, supplied in a metadata column is equal to or not equal to some provided comparator. The target in this case would be the variable that we want to compare the metadata with. This will be used for core permissibility checks.