### PR TITLE
Add operators to compare equality of part of a string using a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ Note: to compare floating point equality we just check that the difference is le
 * `suffix_not_equal_to`
 * `prefix_equal_to`
 * `prefix_not_equal_to`
+* `equals_string_part`
+* `does_not_equal_string_part`
 
 ### Returning data to your client
 

--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/utils.py
+++ b/business_rules/utils.py
@@ -135,6 +135,14 @@ def compare_dates(component, target, comparator, operator):
     else:
         return operator(get_date_component(component, target), get_date_component(component, comparator))
 
+def apply_regex(regex: str, val: str):
+    result = re.findall(regex, val)
+    if result:
+        return result[0]
+    else:
+        return None
+
+vectorized_apply_regex = np.vectorize(apply_regex)
 vectorized_is_complete_date = np.vectorize(is_complete_date)
 vectorized_compare_dates = np.vectorize(compare_dates)
 vectorized_is_valid = np.vectorize(is_valid_date)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,3 @@
-ipdb==0.8
-ipython==1.2.1
 mock==1.0.1
 nose==1.3.1
 nose-run-line-number==0.0.1

--- a/tests/test_dataframe_type/test_string_part_comparison.py
+++ b/tests/test_dataframe_type/test_string_part_comparison.py
@@ -1,0 +1,36 @@
+import pandas
+from . import TestCase
+from business_rules.operators import DataframeType
+
+class StringPartTests(TestCase):
+    def test_equals_string_part(self):
+        df = pandas.DataFrame.from_dict({
+            "RDOMAIN": ["AE", "AE", "DX"],
+            "dataset_name": ["SUPPAEQUAL","SUPPAEQUAL","SUPPAEQUAL"],
+        })
+        self.assertTrue(DataframeType({"value": df}).equals_string_part({
+            "target": "RDOMAIN",
+            "comparator": "dataset_name",
+            "regex": ".{4}(..).*" # Get characters five and six of dataset name
+        }).equals(pandas.Series([True, True, False])))
+        self.assertTrue(DataframeType({"value": df}).equals_string_part({
+            "target": "RDOMAIN",
+            "comparator": "SUDXLL",
+            "regex": ".{2}(..).*" # Get characters five and six of dataset name
+        }).equals(pandas.Series([False, False, True])))
+    
+    def test_does_not_equal_string_part(self):
+        df = pandas.DataFrame.from_dict({
+            "RDOMAIN": ["AE", "AE", "DX"],
+            "dataset_name": ["SUPPAEQUAL","SUPPAEQUAL","SUPPAEQUAL"],
+        })
+        self.assertTrue(DataframeType({"value": df}).does_not_equal_string_part({
+            "target": "RDOMAIN",
+            "comparator": "dataset_name",
+            "regex": ".{4}(..).*" # Get characters five and six of dataset name
+        }).equals(pandas.Series([False, False, True])))
+        self.assertTrue(DataframeType({"value": df}).does_not_equal_string_part({
+            "target": "RDOMAIN",
+            "comparator": "SUDXLL",
+            "regex": ".{2}(..).*" # Get characters five and six of dataset name
+        }).equals(pandas.Series([True, True, False])))


### PR DESCRIPTION
This PR adds two operators

equals_string_part
does_not_equal_string_part

These operators add the ability to compare the equality of the target column with part of the string found in the comparison column. The part of the string is extracted using a regex.

See tests for examples