### PR TITLE
Update valid_date check to apply regex

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/utils.py
+++ b/business_rules/utils.py
@@ -6,6 +6,8 @@ import numpy as np
 from dateutil.parser import parse, isoparse
 import pytz
 
+date_regex = re.compile(r'^((-?(?:[1-9][0-9]*)?[0-9]{4})(-(1[0-2]|0[1-9])(-(3[01]|0[1-9]|[12][0-9])(T(2[0-3]|[01][0-9])(:([0-5][0-9])((:([0-5][0-9]))?(\.[0-9]+)?((Z|[+-](:2[0-3]|[01][0-9]):[0-5][0-9]))?)?)?)?)?)?)$')
+
 def fn_name_to_pretty_label(name):
     return ' '.join([w.title() for w in name.split('_')])
 
@@ -50,7 +52,7 @@ def is_valid_date(date_string: str) -> bool:
         isoparse(date_string)
     except:
         return False
-    return True
+    return date_regex.match(date_string) is not None
 
 def get_year(date_string: str):
     timestamp = get_date(date_string)

--- a/tests/test_dataframe_type/test_valid_date.py
+++ b/tests/test_dataframe_type/test_valid_date.py
@@ -8,17 +8,21 @@ class ValidDateTests(TestCase):
             {
                 "var1": ['2021', '2021', '2021', '2021', '2099', "2022", "2023"],
                 "var2": ["2099", "2022", "2034", "90999", "20999", "2022", "2023"],
+                "var2.1": ["20220311", "2022", "20121123", "2022-03-11T09", "2099", "2022", "2023"],
                 "var3": ["1997-07", "1997-07-16", "1997-07-16T19:20:30.45+01:00", "1997-07-16T19:20:30+01:00", "1997-07-16T19:20+01:00", "2022-05-08T13:44:a", "2022-05-08T13:44:66"], 
             }
         )
         self.assertTrue(DataframeType({"value": df, "column_prefix_map": {"--": "va"}}).invalid_date({"target": "--r1"})
             .equals(pandas.Series([False, False, False, False, False, False, False])))
-        print(DataframeType({"value": df}).invalid_date({"target": "var3"}))
         self.assertTrue(DataframeType({"value": df}).invalid_date({"target": "var3"})
             .equals(pandas.Series([False, False, False, False, False, True, True])))
         self.assertTrue(DataframeType({"value": df}).invalid_date({"target": "var2"})
             .equals(pandas.Series([False, False, False, True, True, False, False])))
-    
+
+        # Test date string can be parsed into a date
+        # Ex: 20121123 cannot be parsed into a date so it is invalid
+        self.assertTrue(DataframeType({"value": df}).invalid_date({"target": "var2.1"})
+                        .equals(pandas.Series([False, False, False, False, False, False, False])))
     def test_invalid_date_incorrect_month_day_values(self):
         df = pandas.DataFrame.from_dict(
             {


### PR DESCRIPTION
Adds regex to catch invalid dates in the form: 20220311

Steps to test:

* Run the tests
* Review the invalid_date tests to ensure edge cases are handled