### PR TITLE
Update Regex operators to evaluate interger and float values.

### DIFF
--- a/business_rules/operators.py
+++ b/business_rules/operators.py
@@ -291,7 +291,7 @@ class DataframeType(BaseType):
                     return value.replace(prefix, replacement, 1)
         return value
 
-    def replace_all_prefixes(self, values: [str]) -> [str]:
+    def replace_all_prefixes(self, values: List[str]) -> List[str]:
         for i in range(len(values)):
             values[i] = self.replace_prefix(values[i])
         return values
@@ -614,40 +614,66 @@ class DataframeType(BaseType):
     def is_not_contained_by_case_insensitive(self, other_value):
         return ~self.is_contained_by_case_insensitive(other_value)
     
+    def _custom_str_conversion(self, x):
+        if pd.notna(x):
+            if isinstance(x, int):
+                return str(x).strip()
+            elif isinstance(x, float):
+                return f"{x:.0f}" if x.is_integer() else str(x).strip()
+        return x
+    
     @type_operator(FIELD_DATAFRAME)
     def prefix_matches_regex(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         prefix = other_value.get("prefix")
-        results = self.value[target].map(lambda x: re.search(comparator, x[:prefix]) is not None)
+        self.value[target] = self.value[target].apply(lambda x: self._custom_str_conversion(x))
+        results = self.value[target].notna() & self.value[target].astype(str).map(lambda x: re.search(comparator, x[:prefix]) is not None)
         return pd.Series(results.values)
     
     @type_operator(FIELD_DATAFRAME)
     def not_prefix_matches_regex(self, other_value):
-        return ~self.prefix_matches_regex(other_value)
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        prefix = other_value.get("prefix")
+        self.value[target] = self.value[target].apply(lambda x: self._custom_str_conversion(x))
+        results = self.value[target].notna() & ~self.value[target].astype(str).map(lambda x: re.search(comparator, x[:prefix]) is not None)
+        return pd.Series(results.values)
+        #return ~self.prefix_matches_regex(other_value)
   
     @type_operator(FIELD_DATAFRAME)
     def suffix_matches_regex(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
         suffix = other_value.get("suffix")
-        results = self.value[target].apply(lambda x: re.search(comparator, x[-suffix:]) is not None)
+        self.value[target] = self.value[target].apply(lambda x: self._custom_str_conversion(x))
+        results = self.value[target].notna() & self.value[target].astype(str).apply(lambda x: re.search(comparator, x[-suffix:]) is not None)
         return pd.Series(results.values)
     
     @type_operator(FIELD_DATAFRAME)
     def not_suffix_matches_regex(self, other_value):
-        return ~self.suffix_matches_regex(other_value)
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        suffix = other_value.get("suffix")
+        self.value[target] = self.value[target].apply(lambda x: self._custom_str_conversion(x))
+        results = self.value[target].notna() & ~self.value[target].astype(str).apply(lambda x: re.search(comparator, x[-suffix:]) is not None)
+        return pd.Series(results.values)
     
     @type_operator(FIELD_DATAFRAME)
     def matches_regex(self, other_value):
         target = self.replace_prefix(other_value.get("target"))
         comparator = other_value.get("comparator")
-        results = self.value[target].str.match(comparator)
+        self.value[target] = self.value[target].apply(lambda x: self._custom_str_conversion(x))
+        results = self.value[target].notna() & self.value[target].astype(str).str.match(comparator)
         return pd.Series(results.values)
     
     @type_operator(FIELD_DATAFRAME)
     def not_matches_regex(self, other_value):
-        return ~self.matches_regex(other_value)
+        target = self.replace_prefix(other_value.get("target"))
+        comparator = other_value.get("comparator")
+        self.value[target] = self.value[target].apply(lambda x: self._custom_str_conversion(x))
+        results = self.value[target].notna() & ~self.value[target].astype(str).str.match(comparator)
+        return pd.Series(results.values)
 
     @type_operator(FIELD_DATAFRAME)
     def equals_string_part(self, other_value):


### PR DESCRIPTION
The following operators were updated to accomodate checks of integer and float values against a regular expression. Missing values are left out on purpose from the checks.

Operators updated:

* prefix_matches_regex
* not_prefix_matches_regex
* suffix_matches_regex
* not_suffix_matches_regex
* matches_regex
* not_matches_regex

A new method "_custom_str_conversion" was also created to convert integer and float values to strings.