### PR TITLE
updated case insensitive contains

### DIFF
--- a/business_rules/__init__.py
+++ b/business_rules/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 
 from .engine import run_all
 from .utils import export_rule_data

--- a/business_rules/six.py
+++ b/business_rules/six.py
@@ -25,7 +25,7 @@ import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 
 
 # Useful for very coarse version differentiation.

--- a/business_rules/utils.py
+++ b/business_rules/utils.py
@@ -162,7 +162,7 @@ def is_in(value, values):
     return value in values
 
 def case_insensitive_is_in(value, values):
-    return value.lower() in map(str.lower, values)
+    return str(value).lower() in str(name).lower()
 
 def compare_dates(component, target, comparator, operator):
     if not target or not comparator:


### PR DESCRIPTION
This PR fixes the case_insensitive_is_in and thus contains_case_insensitive operator.   The original was checking if the entire value matches any element in a list of values--looking for full matches, not substring matches as described in the reference guide.  The new operator aligns with the reference guide and checks if one string is contained within target, both using lower() to make it case insensitive